### PR TITLE
feat: implement user inventory schema with locations

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { GamesModule } from './modules/games/games.module';
 import { UexModule } from './modules/uex/uex.module';
 import { UexSyncModule } from './modules/uex-sync/uex-sync.module';
 import { LocationsModule } from './modules/locations/locations.module';
+import { UserInventoryModule } from './modules/user-inventory/user-inventory.module';
 
 const isTest =
   process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID !== undefined;
@@ -112,6 +113,7 @@ if (!isTest) {
     UexModule,
     UexSyncModule,
     LocationsModule,
+    UserInventoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/modules/user-inventory/dto/user-inventory-item.dto.ts
+++ b/backend/src/modules/user-inventory/dto/user-inventory-item.dto.ts
@@ -1,0 +1,113 @@
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsBoolean,
+  Min,
+  Max,
+  IsInt,
+} from 'class-validator';
+
+export class UserInventoryItemDto {
+  id!: string;
+  userId!: number;
+  gameId!: number;
+  uexItemId!: number;
+  locationId!: number;
+  quantity!: number;
+  notes?: string;
+  sharedOrgId?: number;
+  active!: boolean;
+  dateAdded!: Date;
+  dateModified!: Date;
+
+  // Populated from relations
+  itemName?: string;
+  locationName?: string;
+  sharedOrgName?: string;
+}
+
+export class CreateUserInventoryItemDto {
+  @IsInt()
+  gameId!: number;
+
+  @IsInt()
+  uexItemId!: number;
+
+  @IsInt()
+  locationId!: number;
+
+  @IsNumber()
+  @Min(0.01)
+  @Max(999999999.99)
+  quantity!: number;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsOptional()
+  @IsInt()
+  sharedOrgId?: number;
+}
+
+export class UpdateUserInventoryItemDto {
+  @IsOptional()
+  @IsInt()
+  locationId?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0.01)
+  @Max(999999999.99)
+  quantity?: number;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsOptional()
+  @IsInt()
+  sharedOrgId?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class UserInventorySearchDto {
+  @IsInt()
+  gameId!: number;
+
+  @IsOptional()
+  @IsInt()
+  uexItemId?: number;
+
+  @IsOptional()
+  @IsInt()
+  locationId?: number;
+
+  @IsOptional()
+  @IsInt()
+  sharedOrgId?: number;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number;
+}
+
+export class UserInventorySummaryDto {
+  userId!: number;
+  gameId!: number;
+  totalItems!: number;
+  uniqueItems!: number;
+  locationCount!: number;
+  sharedItemsCount!: number;
+  lastUpdated!: Date;
+}

--- a/backend/src/modules/user-inventory/entities/user-inventory-item.entity.ts
+++ b/backend/src/modules/user-inventory/entities/user-inventory-item.entity.ts
@@ -1,0 +1,106 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/user.entity';
+import { Game } from '../../games/game.entity';
+import { UexItem } from '../../uex/entities/uex-item.entity';
+import { Location } from '../../locations/entities/location.entity';
+import { Organization } from '../../organizations/organization.entity';
+
+@Entity('user_inventory_items')
+@Index('idx_user_inv_list', ['userId', 'gameId', 'deleted', 'active'], {
+  where: 'deleted = FALSE',
+})
+@Index('idx_user_inv_org_view', ['sharedOrgId', 'uexItemId'], {
+  where: 'deleted = FALSE AND shared_org_id IS NOT NULL',
+})
+@Index('idx_user_inv_item_agg', ['userId', 'uexItemId', 'deleted'], {
+  where: 'deleted = FALSE',
+})
+@Index('idx_user_inv_recent', ['userId', 'dateModified'], {
+  where: 'deleted = FALSE',
+})
+export class UserInventoryItem {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  @Index()
+  userId!: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+
+  @Column({ name: 'game_id', type: 'integer' })
+  @Index()
+  gameId!: number;
+
+  @ManyToOne(() => Game)
+  @JoinColumn({ name: 'game_id' })
+  game!: Game;
+
+  @Column({ name: 'uex_item_id', type: 'integer' })
+  @Index()
+  uexItemId!: number;
+
+  @ManyToOne(() => UexItem)
+  @JoinColumn({ name: 'uex_item_id', referencedColumnName: 'uexId' })
+  item!: UexItem;
+
+  @Column({ name: 'location_id', type: 'bigint' })
+  @Index()
+  locationId!: number;
+
+  @ManyToOne(() => Location)
+  @JoinColumn({ name: 'location_id' })
+  location!: Location;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  quantity!: number;
+
+  @Column({ type: 'text', nullable: true })
+  notes?: string;
+
+  @Column({ name: 'shared_org_id', type: 'bigint', nullable: true })
+  @Index()
+  sharedOrgId?: number;
+
+  @ManyToOne(() => Organization, { nullable: true })
+  @JoinColumn({ name: 'shared_org_id' })
+  sharedOrg?: Organization;
+
+  @Column({ default: true })
+  active!: boolean;
+
+  @Column({ default: false })
+  @Index()
+  deleted!: boolean;
+
+  @CreateDateColumn({ name: 'date_added', type: 'timestamptz' })
+  dateAdded!: Date;
+
+  @UpdateDateColumn({ name: 'date_modified', type: 'timestamptz' })
+  dateModified!: Date;
+
+  @Column({ name: 'added_by', type: 'bigint' })
+  addedBy!: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'added_by' })
+  addedByUser!: User;
+
+  @Column({ name: 'modified_by', type: 'bigint' })
+  modifiedBy!: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'modified_by' })
+  modifiedByUser!: User;
+}

--- a/backend/src/modules/user-inventory/user-inventory.module.ts
+++ b/backend/src/modules/user-inventory/user-inventory.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserInventoryItem } from './entities/user-inventory-item.entity';
+import { UserInventoryService } from './user-inventory.service';
+import { User } from '../users/user.entity';
+import { Game } from '../games/game.entity';
+import { UexItem } from '../uex/entities/uex-item.entity';
+import { Location } from '../locations/entities/location.entity';
+import { Organization } from '../organizations/organization.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      UserInventoryItem,
+      User,
+      Game,
+      UexItem,
+      Location,
+      Organization,
+    ]),
+  ],
+  providers: [UserInventoryService],
+  exports: [UserInventoryService],
+})
+export class UserInventoryModule {}

--- a/backend/src/modules/user-inventory/user-inventory.service.spec.ts
+++ b/backend/src/modules/user-inventory/user-inventory.service.spec.ts
@@ -1,0 +1,288 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { UserInventoryService } from './user-inventory.service';
+import { UserInventoryItem } from './entities/user-inventory-item.entity';
+import {
+  CreateUserInventoryItemDto,
+  UpdateUserInventoryItemDto,
+  UserInventorySearchDto,
+} from './dto/user-inventory-item.dto';
+
+describe('UserInventoryService', () => {
+  let service: UserInventoryService;
+  let repository: Repository<UserInventoryItem>;
+
+  const mockInventoryItem: UserInventoryItem = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    userId: 1,
+    gameId: 1,
+    uexItemId: 100,
+    locationId: 200,
+    quantity: 10.5,
+    notes: 'Test item',
+    sharedOrgId: undefined,
+    active: true,
+    deleted: false,
+    dateAdded: new Date(),
+    dateModified: new Date(),
+    addedBy: 1,
+    modifiedBy: 1,
+    user: undefined as any,
+    game: undefined as any,
+    item: { name: 'Test Item' } as any,
+    location: { displayName: 'Test Location' } as any,
+    sharedOrg: undefined,
+    addedByUser: undefined as any,
+    modifiedByUser: undefined as any,
+  };
+
+  const mockQueryBuilder: any = {
+    createQueryBuilder: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    getRawOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserInventoryService,
+        {
+          provide: getRepositoryToken(UserInventoryItem),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            createQueryBuilder: jest.fn(() => mockQueryBuilder),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserInventoryService>(UserInventoryService);
+    repository = module.get<Repository<UserInventoryItem>>(
+      getRepositoryToken(UserInventoryItem),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('should return all inventory items for a user', async () => {
+      const searchDto: UserInventorySearchDto = { gameId: 1 };
+      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+
+      const result = await service.findAll(1, searchDto);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockInventoryItem.id);
+      expect(result[0].itemName).toBe('Test Item');
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'inventory.user_id = :userId',
+        { userId: 1 },
+      );
+    });
+
+    it('should filter by uexItemId', async () => {
+      const searchDto: UserInventorySearchDto = { gameId: 1, uexItemId: 100 };
+      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+
+      await service.findAll(1, searchDto);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'inventory.uex_item_id = :uexItemId',
+        { uexItemId: 100 },
+      );
+    });
+
+    it('should filter by locationId', async () => {
+      const searchDto: UserInventorySearchDto = {
+        gameId: 1,
+        locationId: 200,
+      };
+      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+
+      await service.findAll(1, searchDto);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'inventory.location_id = :locationId',
+        { locationId: 200 },
+      );
+    });
+
+    it('should filter by search text', async () => {
+      const searchDto: UserInventorySearchDto = {
+        gameId: 1,
+        search: 'test',
+      };
+      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+
+      await service.findAll(1, searchDto);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        '(item.name ILIKE :search OR inventory.notes ILIKE :search)',
+        { search: '%test%' },
+      );
+    });
+  });
+
+  describe('findById', () => {
+    it('should return an inventory item by id', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockInventoryItem);
+
+      const result = await service.findById(mockInventoryItem.id, 1);
+
+      expect(result.id).toBe(mockInventoryItem.id);
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { id: mockInventoryItem.id, userId: 1, deleted: false },
+        relations: ['item', 'location', 'sharedOrg'],
+      });
+    });
+
+    it('should throw NotFoundException if item not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.findById('invalid-id', 1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new inventory item', async () => {
+      const createDto: CreateUserInventoryItemDto = {
+        gameId: 1,
+        uexItemId: 100,
+        locationId: 200,
+        quantity: 10.5,
+        notes: 'New item',
+      };
+
+      jest.spyOn(repository, 'create').mockReturnValue(mockInventoryItem);
+      jest.spyOn(repository, 'save').mockResolvedValue(mockInventoryItem);
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockInventoryItem);
+
+      const result = await service.create(1, createDto);
+
+      expect(result.id).toBe(mockInventoryItem.id);
+      expect(repository.create).toHaveBeenCalledWith({
+        ...createDto,
+        userId: 1,
+        addedBy: 1,
+        modifiedBy: 1,
+      });
+      expect(repository.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('should update an existing inventory item', async () => {
+      const updateDto: UpdateUserInventoryItemDto = {
+        quantity: 20,
+        notes: 'Updated notes',
+      };
+
+      const updatedItem = { ...mockInventoryItem, ...updateDto };
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockInventoryItem);
+      jest.spyOn(repository, 'save').mockResolvedValue(updatedItem);
+
+      const result = await service.update(mockInventoryItem.id, 1, updateDto);
+
+      expect(result.quantity).toBe(20);
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modifiedBy: 1,
+        }),
+      );
+    });
+
+    it('should throw NotFoundException if item not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.update('invalid-id', 1, { quantity: 20 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('delete', () => {
+    it('should soft delete an inventory item', async () => {
+      const deletedItem = {
+        ...mockInventoryItem,
+        deleted: true,
+        active: false,
+      };
+      jest.spyOn(repository, 'findOne').mockResolvedValue(mockInventoryItem);
+      jest.spyOn(repository, 'save').mockResolvedValue(deletedItem);
+
+      await service.delete(mockInventoryItem.id, 1);
+
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deleted: true,
+          active: false,
+          modifiedBy: 1,
+        }),
+      );
+    });
+
+    it('should throw NotFoundException if item not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.delete('invalid-id', 1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should return inventory summary for a user', async () => {
+      mockQueryBuilder.getRawOne.mockResolvedValue({
+        totalItems: '10',
+        uniqueItems: '5',
+        locationCount: '3',
+        sharedItemsCount: '2',
+        lastUpdated: new Date(),
+      });
+
+      const result = await service.getSummary(1, 1);
+
+      expect(result.totalItems).toBe(10);
+      expect(result.uniqueItems).toBe(5);
+      expect(result.locationCount).toBe(3);
+      expect(result.sharedItemsCount).toBe(2);
+    });
+  });
+
+  describe('findSharedByOrg', () => {
+    it('should return shared items for an organization', async () => {
+      jest.spyOn(repository, 'find').mockResolvedValue([mockInventoryItem]);
+
+      const result = await service.findSharedByOrg(1, 1);
+
+      expect(result).toHaveLength(1);
+      expect(repository.find).toHaveBeenCalledWith({
+        where: {
+          sharedOrgId: 1,
+          gameId: 1,
+          deleted: false,
+          active: true,
+        },
+        relations: ['item', 'location', 'user'],
+        order: { dateModified: 'DESC' },
+        take: 100,
+      });
+    });
+  });
+});

--- a/backend/src/modules/user-inventory/user-inventory.service.ts
+++ b/backend/src/modules/user-inventory/user-inventory.service.ts
@@ -1,0 +1,214 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserInventoryItem } from './entities/user-inventory-item.entity';
+import {
+  UserInventoryItemDto,
+  CreateUserInventoryItemDto,
+  UpdateUserInventoryItemDto,
+  UserInventorySearchDto,
+  UserInventorySummaryDto,
+} from './dto/user-inventory-item.dto';
+
+@Injectable()
+export class UserInventoryService {
+  private readonly logger = new Logger(UserInventoryService.name);
+
+  constructor(
+    @InjectRepository(UserInventoryItem)
+    private readonly inventoryRepository: Repository<UserInventoryItem>,
+  ) {}
+
+  async findAll(
+    userId: number,
+    searchDto: UserInventorySearchDto,
+  ): Promise<UserInventoryItemDto[]> {
+    const queryBuilder = this.inventoryRepository
+      .createQueryBuilder('inventory')
+      .leftJoinAndSelect('inventory.item', 'item')
+      .leftJoinAndSelect('inventory.location', 'location')
+      .leftJoinAndSelect('inventory.sharedOrg', 'sharedOrg')
+      .where('inventory.user_id = :userId', { userId })
+      .andWhere('inventory.game_id = :gameId', { gameId: searchDto.gameId })
+      .andWhere('inventory.deleted = FALSE')
+      .andWhere('inventory.active = TRUE');
+
+    if (searchDto.uexItemId) {
+      queryBuilder.andWhere('inventory.uex_item_id = :uexItemId', {
+        uexItemId: searchDto.uexItemId,
+      });
+    }
+
+    if (searchDto.locationId) {
+      queryBuilder.andWhere('inventory.location_id = :locationId', {
+        locationId: searchDto.locationId,
+      });
+    }
+
+    if (searchDto.sharedOrgId) {
+      queryBuilder.andWhere('inventory.shared_org_id = :sharedOrgId', {
+        sharedOrgId: searchDto.sharedOrgId,
+      });
+    }
+
+    if (searchDto.search) {
+      queryBuilder.andWhere(
+        '(item.name ILIKE :search OR inventory.notes ILIKE :search)',
+        { search: `%${searchDto.search}%` },
+      );
+    }
+
+    queryBuilder.orderBy('inventory.date_modified', 'DESC');
+    queryBuilder.take(searchDto.limit || 100);
+
+    const items = await queryBuilder.getMany();
+
+    return items.map((item) => this.toDto(item));
+  }
+
+  async findById(id: string, userId: number): Promise<UserInventoryItemDto> {
+    const item = await this.inventoryRepository.findOne({
+      where: { id, userId, deleted: false },
+      relations: ['item', 'location', 'sharedOrg'],
+    });
+
+    if (!item) {
+      throw new NotFoundException(`Inventory item with ID ${id} not found`);
+    }
+
+    return this.toDto(item);
+  }
+
+  async create(
+    userId: number,
+    createDto: CreateUserInventoryItemDto,
+  ): Promise<UserInventoryItemDto> {
+    const item = this.inventoryRepository.create({
+      ...createDto,
+      userId,
+      addedBy: userId,
+      modifiedBy: userId,
+    });
+
+    const saved = await this.inventoryRepository.save(item);
+
+    this.logger.log(
+      `Created inventory item ${saved.id} for user ${userId}: ${createDto.quantity}x item ${createDto.uexItemId}`,
+    );
+
+    return this.findById(saved.id, userId);
+  }
+
+  async update(
+    id: string,
+    userId: number,
+    updateDto: UpdateUserInventoryItemDto,
+  ): Promise<UserInventoryItemDto> {
+    const item = await this.findInventoryItem(id, userId);
+
+    Object.assign(item, updateDto);
+    item.modifiedBy = userId;
+
+    const saved = await this.inventoryRepository.save(item);
+
+    this.logger.log(`Updated inventory item ${saved.id} for user ${userId}`);
+
+    return this.findById(saved.id, userId);
+  }
+
+  async delete(id: string, userId: number): Promise<void> {
+    const item = await this.findInventoryItem(id, userId);
+
+    item.deleted = true;
+    item.active = false;
+    item.modifiedBy = userId;
+
+    await this.inventoryRepository.save(item);
+
+    this.logger.log(`Deleted inventory item ${id} for user ${userId}`);
+  }
+
+  async getSummary(
+    userId: number,
+    gameId: number,
+  ): Promise<UserInventorySummaryDto> {
+    const result = await this.inventoryRepository
+      .createQueryBuilder('inventory')
+      .select('COUNT(*)', 'totalItems')
+      .addSelect('COUNT(DISTINCT inventory.uex_item_id)', 'uniqueItems')
+      .addSelect('COUNT(DISTINCT inventory.location_id)', 'locationCount')
+      .addSelect(
+        'SUM(CASE WHEN inventory.shared_org_id IS NOT NULL THEN 1 ELSE 0 END)',
+        'sharedItemsCount',
+      )
+      .addSelect('MAX(inventory.date_modified)', 'lastUpdated')
+      .where('inventory.user_id = :userId', { userId })
+      .andWhere('inventory.game_id = :gameId', { gameId })
+      .andWhere('inventory.deleted = FALSE')
+      .andWhere('inventory.active = TRUE')
+      .getRawOne();
+
+    return {
+      userId,
+      gameId,
+      totalItems: parseInt(result.totalItems || '0', 10),
+      uniqueItems: parseInt(result.uniqueItems || '0', 10),
+      locationCount: parseInt(result.locationCount || '0', 10),
+      sharedItemsCount: parseInt(result.sharedItemsCount || '0', 10),
+      lastUpdated: result.lastUpdated || new Date(),
+    };
+  }
+
+  async findSharedByOrg(
+    orgId: number,
+    gameId: number,
+  ): Promise<UserInventoryItemDto[]> {
+    const items = await this.inventoryRepository.find({
+      where: {
+        sharedOrgId: orgId,
+        gameId,
+        deleted: false,
+        active: true,
+      },
+      relations: ['item', 'location', 'user'],
+      order: { dateModified: 'DESC' },
+      take: 100,
+    });
+
+    return items.map((item) => this.toDto(item));
+  }
+
+  private async findInventoryItem(
+    id: string,
+    userId: number,
+  ): Promise<UserInventoryItem> {
+    const item = await this.inventoryRepository.findOne({
+      where: { id, userId, deleted: false },
+    });
+
+    if (!item) {
+      throw new NotFoundException(`Inventory item with ID ${id} not found`);
+    }
+
+    return item;
+  }
+
+  private toDto(item: UserInventoryItem): UserInventoryItemDto {
+    return {
+      id: item.id,
+      userId: item.userId,
+      gameId: item.gameId,
+      uexItemId: item.uexItemId,
+      locationId: item.locationId,
+      quantity: parseFloat(item.quantity.toString()),
+      notes: item.notes,
+      sharedOrgId: item.sharedOrgId,
+      active: item.active,
+      dateAdded: item.dateAdded,
+      dateModified: item.dateModified,
+      itemName: item.item?.name,
+      locationName: item.location?.displayName,
+      sharedOrgName: item.sharedOrg?.name,
+    };
+  }
+}


### PR DESCRIPTION
Implements Issue #18: User Inventory Schema

Core Features:

- UserInventoryItem entity with UUID primary key

- Polymorphic relationships to User, Game, UexItem, Location, Organization

- Per-location quantity tracking (decimal 12,2 precision)

- Optional organization sharing (shared_org_id)

- Soft delete and audit tracking

Indexes for Performance:

- User inventory list (user_id, game_id, deleted, active)

- Org shared items view (shared_org_id, uex_item_id)

- Item aggregation (user_id, uex_item_id, deleted)

- Recently modified (user_id, date_modified DESC)

Service Operations:

- CRUD operations with user ownership validation

- Search/filter by game, item, location, organization, text

- Inventory summary stats (total, unique items, locations, shared)

- Organization shared items query

- Automatic soft delete on delete operation

DTOs:

- UserInventoryItemDto: API response with populated relations

- CreateUserInventoryItemDto: Validation for quantity (0.01-999999999.99)

- UpdateUserInventoryItemDto: Partial updates

- UserInventorySearchDto: Filtering parameters

- UserInventorySummaryDto: Aggregated statistics

Tests: 13 new unit tests, all 204 backend tests passing