### PR TITLE
feat: implement org inventory schema and API endpoints

### DIFF
--- a/backend/docs/inventory/org-vs-user-inventory.md
+++ b/backend/docs/inventory/org-vs-user-inventory.md
@@ -1,0 +1,313 @@
+# Organization vs User Inventory: Architecture and Design
+
+## Overview
+
+The Station inventory system uses two distinct models to handle different ownership scenarios:
+
+1. **User Inventory** (`user_inventory_items`) - Items owned by individual users that can optionally be shared with organizations for visibility
+2. **Organization Inventory** (`org_inventory_items`) - Items fully owned and managed by organizations
+
+This document explains the distinction, use cases, and future transfer workflow design.
+
+---
+
+## Key Differences
+
+### User Inventory (`user_inventory_items`)
+
+**Purpose**: Track items owned by individual users with optional organization visibility
+
+**Key Fields**:
+
+- `user_id` - The owner of the item
+- `shared_org_id` - Optional: Organization the item is shared with for visibility
+- When `shared_org_id` is set, org members can VIEW the item but the user retains full ownership
+
+**Use Cases**:
+
+- Personal player inventory tracking
+- Ship ownership where user wants to show their fleet to org
+- Resource tracking where user contributes visibility but maintains control
+- Temporary org access without transferring ownership
+
+**Permissions**:
+
+- User has full control (view, edit, delete)
+- If shared with org, org members with `inventory.view` can see it
+- Org members CANNOT modify user-owned items (read-only visibility)
+
+**Example Flow**:
+
+```
+User Alice owns a Carrack ship
+Alice shares it with "Mining Corp" org
+Mining Corp members can see Alice owns a Carrack
+Alice can unshare at any time
+If Alice leaves the org, sharing is auto-revoked via trigger
+```
+
+### Organization Inventory (`org_inventory_items`)
+
+**Purpose**: Track items fully owned and controlled by the organization
+
+**Key Fields**:
+
+- `org_id` - The organization that owns the item
+- `added_by` / `modified_by` - Which org member created/edited (for accountability)
+- NO `shared_org_id` field - org owns it outright
+
+**Use Cases**:
+
+- Org-purchased ships and equipment
+- Pooled resources contributed by members (after transfer)
+- Org base inventory and stockpiles
+- Fleet management where org owns the assets
+
+**Permissions**:
+
+- Org members with `inventory.manage` can create, edit, delete
+- Org members with `inventory.view` can see all org inventory
+- Individual users have NO access unless they're org members
+
+**Example Flow**:
+
+```
+"Mining Corp" purchases a Prospector using org funds
+Org treasurer creates org inventory item
+All org members with inventory.view can see it
+Only members with inventory.manage can modify it
+Item persists even if members leave the org
+```
+
+---
+
+## Comparison Table
+
+| Feature      | User Inventory              | Org Inventory                       |
+| ------------ | --------------------------- | ----------------------------------- |
+| Owner        | Individual User             | Organization                        |
+| Sharing      | Optional (read-only to org) | N/A (org owns it)                   |
+| Edit Access  | User only                   | Org members with `inventory.manage` |
+| View Access  | User + shared org (if set)  | Org members with `inventory.view`   |
+| Persistence  | Tied to user account        | Tied to organization                |
+| Transfer     | Future: User → Org          | Future: Org → User or Org → Org     |
+| Added By     | User (self)                 | Org member (tracked)                |
+| Auto-unshare | Yes (when user leaves org)  | N/A                                 |
+
+---
+
+## Future Transfer Workflow Design (Post-MVP)
+
+### User → Organization Transfer
+
+Allows users to transfer ownership of their items to an organization.
+
+**Workflow**:
+
+1. User creates transfer request specifying item and org
+2. Org admin with `inventory.manage` reviews request
+3. If approved:
+   - Original `user_inventory_item` soft-deleted OR quantity reduced
+   - New `org_inventory_item` created with same item/location
+   - Transfer logged in `inventory_audit_log`
+   - Both user and org admins notified
+
+**Transfer Request Model** (placeholder):
+
+```typescript
+interface InventoryTransferRequest {
+  id: string;
+  from_user_id: string;
+  to_org_id: string;
+  user_inventory_item_id: string;
+  quantity: number;
+  status: 'pending' | 'approved' | 'rejected' | 'completed';
+  requested_at: Date;
+  approved_by?: string;
+  approved_at?: Date;
+  notes?: string;
+}
+```
+
+**Validation Rules**:
+
+- User must be member of target org
+- User must own the item (not already transferred)
+- Quantity must not exceed available quantity
+- Transfer must be approved by org admin with `inventory.manage`
+
+**Audit Trail**:
+
+```json
+{
+  "action": "INVENTORY_TRANSFER",
+  "from_user_id": 123,
+  "to_org_id": 456,
+  "item_id": "abc-123",
+  "quantity": 100,
+  "approved_by": 789,
+  "timestamp": "2025-12-05T10:00:00Z"
+}
+```
+
+### Organization → User Transfer
+
+Allows orgs to distribute items to members.
+
+**Workflow**:
+
+1. Org admin with `inventory.manage` creates transfer to user
+2. User receives notification
+3. User accepts or rejects
+4. If accepted:
+   - `org_inventory_item` soft-deleted OR quantity reduced
+   - New `user_inventory_item` created
+   - Transfer logged in audit trail
+
+**Use Cases**:
+
+- Rewarding members with org-owned items
+- Distributing supplies for missions
+- Gifting items to departing members
+
+---
+
+## Auto-Unshare on Member Removal
+
+When a user leaves an organization (via `user_organization_role` deletion):
+
+**User Inventory Behavior**:
+
+- Database trigger automatically sets `shared_org_id = NULL`
+- Item remains in user's inventory
+- Org loses visibility immediately
+
+**Org Inventory Behavior**:
+
+- No automatic changes (org owns the items)
+- User loses access to org inventory immediately via permissions
+- User cannot take org items with them
+
+**Implementation**: See `AddAutoUnshareInventoryTrigger` migration
+
+---
+
+## Permission Definitions
+
+### `inventory.view`
+
+- View user inventory items shared with org
+- View all org inventory items
+
+### `inventory.manage`
+
+- Create, update, delete org inventory items
+- Approve user → org transfers (future)
+- Cannot modify user-owned items (even if shared)
+
+### `inventory.admin` (future)
+
+- All `inventory.manage` permissions
+- Approve org → user transfers
+- Manage inventory policies
+- View full audit logs
+
+---
+
+## Database Schema Highlights
+
+### User Inventory Table
+
+```sql
+CREATE TABLE user_inventory_items (
+  id UUID PRIMARY KEY,
+  user_id BIGINT REFERENCES user(id),
+  shared_org_id INTEGER REFERENCES organization(id), -- Optional sharing
+  -- ... other fields
+);
+```
+
+### Org Inventory Table
+
+```sql
+CREATE TABLE org_inventory_items (
+  id UUID PRIMARY KEY,
+  org_id INTEGER REFERENCES organization(id), -- Full ownership
+  added_by BIGINT REFERENCES user(id), -- Accountability
+  modified_by BIGINT REFERENCES user(id),
+  -- ... other fields
+  -- NO shared_org_id field!
+);
+```
+
+---
+
+## API Endpoints
+
+### User Inventory
+
+- `GET /user-inventory` - Get my inventory
+- `POST /user-inventory` - Add item to my inventory
+- `PUT /user-inventory/:id/share` - Share with org (set `shared_org_id`)
+- `PUT /user-inventory/:id/unshare` - Unshare from org
+
+### Org Inventory
+
+- `GET /org-inventory/org/:orgId/game/:gameId` - Get org inventory (requires `inventory.view`)
+- `POST /org-inventory` - Add item to org inventory (requires `inventory.manage`)
+- `PUT /org-inventory/:id` - Update org item (requires `inventory.manage`)
+- `DELETE /org-inventory/:id` - Soft delete org item (requires `inventory.manage`)
+
+---
+
+## Migration Path
+
+For existing deployments:
+
+1. **Phase 1 (Current)**: User inventory with sharing
+2. **Phase 2 (Issue #19)**: Org inventory schema
+3. **Phase 3 (Future)**: Transfer workflow
+4. **Phase 4 (Future)**: Org → Org transfers for alliances
+
+No data migration needed - both systems coexist independently.
+
+---
+
+## Testing Considerations
+
+### User Inventory Tests
+
+- Sharing/unsharing behavior
+- Auto-unshare on org removal
+- Permission checks for shared visibility
+- User retains full control of shared items
+
+### Org Inventory Tests
+
+- Permission checks for view/manage
+- Org ownership scenarios
+- Org member add/remove doesn't affect org items
+- Audit trail for accountability
+
+### Transfer Tests (Future)
+
+- Request/approve workflow
+- Quantity validation
+- Audit logging
+- Notification delivery
+- Rollback on failure
+
+---
+
+## Summary
+
+**User Inventory** = "I own this, but I'll let the org see it"
+**Org Inventory** = "The org owns this, and I'm managing it on behalf of the org"
+
+This separation ensures:
+
+- Clear ownership boundaries
+- Proper permission enforcement
+- Future transfer capability
+- Audit trail accountability
+- User privacy and control

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { UexModule } from './modules/uex/uex.module';
 import { UexSyncModule } from './modules/uex-sync/uex-sync.module';
 import { LocationsModule } from './modules/locations/locations.module';
 import { UserInventoryModule } from './modules/user-inventory/user-inventory.module';
+import { OrgInventoryModule } from './modules/org-inventory/org-inventory.module';
 
 const isTest =
   process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID !== undefined;
@@ -114,6 +115,7 @@ if (!isTest) {
     UexSyncModule,
     LocationsModule,
     UserInventoryModule,
+    OrgInventoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/migrations/1764964935270-CreateOrgInventoryItemsTable.ts
+++ b/backend/src/migrations/1764964935270-CreateOrgInventoryItemsTable.ts
@@ -1,0 +1,137 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates org inventory items table for organization-owned assets
+ *
+ * IMPORTANT: Before running this migration:
+ * 1. Create a backup using: pnpm db:backup
+ * 2. Review the pre-migration checklist in docs/database/migrations.md
+ * 3. Test the migration in a development environment
+ * 4. Verify the down() method can successfully rollback changes
+ *
+ * Description: Creates the org_inventory_items table for tracking org-owned
+ * inventory with per-location quantities, soft-delete support, and audit trails.
+ * This is distinct from user_inventory_items (which tracks user-owned items
+ * that can be shared with orgs for visibility).
+ *
+ * Estimated duration: < 15 seconds
+ * Rollback safe: Yes - drops table entirely (no data loss if no inventory created)
+ */
+export class CreateOrgInventoryItemsTable1764964935270
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create org_inventory_items table
+    await queryRunner.query(`
+      CREATE TABLE "org_inventory_items" (
+        "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+        -- Core ownership and item references
+        "org_id" INTEGER NOT NULL REFERENCES "organization"("id") ON DELETE CASCADE,
+        "game_id" INTEGER NOT NULL REFERENCES "games"("id"),
+        "uex_item_id" INTEGER NOT NULL REFERENCES "uex_items"("uex_id"),
+        "location_id" BIGINT NOT NULL REFERENCES "locations"("id"),
+
+        -- Quantity and notes
+        "quantity" DECIMAL(12,2) NOT NULL CHECK ("quantity" > 0),
+        "notes" TEXT,
+
+        -- Status flags
+        "active" BOOLEAN NOT NULL DEFAULT TRUE,
+        "deleted" BOOLEAN NOT NULL DEFAULT FALSE,
+
+        -- Audit fields
+        "date_added" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "date_modified" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "added_by" BIGINT NOT NULL REFERENCES "user"("id"),
+        "modified_by" BIGINT NOT NULL REFERENCES "user"("id")
+      )
+    `);
+
+    // Create indexes for common query patterns
+
+    // Fast org inventory list by org and game
+    await queryRunner.query(`
+      CREATE INDEX "idx_org_inv_org_game"
+      ON "org_inventory_items"("org_id", "game_id", "deleted")
+      WHERE "deleted" = FALSE
+    `);
+
+    // Item lookup queries
+    await queryRunner.query(`
+      CREATE INDEX "idx_org_inv_item"
+      ON "org_inventory_items"("uex_item_id")
+      WHERE "deleted" = FALSE
+    `);
+
+    // Location-based queries
+    await queryRunner.query(`
+      CREATE INDEX "idx_org_inv_location"
+      ON "org_inventory_items"("location_id")
+      WHERE "deleted" = FALSE
+    `);
+
+    // Recently modified for activity feeds
+    await queryRunner.query(`
+      CREATE INDEX "idx_org_inv_recent"
+      ON "org_inventory_items"("org_id", "date_modified" DESC)
+      WHERE "deleted" = FALSE
+    `);
+
+    // Active items filter
+    await queryRunner.query(`
+      CREATE INDEX "idx_org_inv_active"
+      ON "org_inventory_items"("org_id", "active")
+      WHERE "deleted" = FALSE
+    `);
+
+    // Create quantity validation trigger (reuse existing function from user inventory)
+    await queryRunner.query(`
+      CREATE TRIGGER trigger_validate_org_inventory_quantity
+        BEFORE INSERT OR UPDATE ON "org_inventory_items"
+        FOR EACH ROW
+        EXECUTE FUNCTION validate_inventory_quantity();
+    `);
+
+    // Create auto-update modified timestamp trigger
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION update_org_inventory_modified_timestamp()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        NEW.date_modified = NOW();
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER trigger_update_org_inventory_modified
+        BEFORE UPDATE ON "org_inventory_items"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_org_inventory_modified_timestamp();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop triggers and functions
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS trigger_update_org_inventory_modified ON "org_inventory_items"`,
+    );
+    await queryRunner.query(
+      `DROP FUNCTION IF EXISTS update_org_inventory_modified_timestamp()`,
+    );
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS trigger_validate_org_inventory_quantity ON "org_inventory_items"`,
+    );
+
+    // Drop indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_org_inv_active"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_org_inv_recent"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_org_inv_location"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_org_inv_item"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_org_inv_org_game"`);
+
+    // Drop table
+    await queryRunner.query(`DROP TABLE IF EXISTS "org_inventory_items"`);
+  }
+}

--- a/backend/src/modules/org-inventory/dto/org-inventory-item.dto.ts
+++ b/backend/src/modules/org-inventory/dto/org-inventory-item.dto.ts
@@ -1,0 +1,118 @@
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsBoolean,
+  Min,
+  Max,
+  IsInt,
+} from 'class-validator';
+
+export class OrgInventoryItemDto {
+  id!: string;
+  orgId!: number;
+  gameId!: number;
+  uexItemId!: number;
+  locationId!: number;
+  quantity!: number;
+  notes?: string;
+  active!: boolean;
+  dateAdded!: Date;
+  dateModified!: Date;
+  addedBy!: number;
+  modifiedBy!: number;
+
+  // Populated from relations
+  itemName?: string;
+  locationName?: string;
+  orgName?: string;
+  addedByUsername?: string;
+  modifiedByUsername?: string;
+}
+
+export class CreateOrgInventoryItemDto {
+  @IsInt()
+  orgId!: number;
+
+  @IsInt()
+  gameId!: number;
+
+  @IsInt()
+  uexItemId!: number;
+
+  @IsInt()
+  locationId!: number;
+
+  @IsNumber()
+  @Min(0.01)
+  @Max(999999999.99)
+  quantity!: number;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+export class UpdateOrgInventoryItemDto {
+  @IsOptional()
+  @IsInt()
+  locationId?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0.01)
+  @Max(999999999.99)
+  quantity?: number;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class OrgInventorySearchDto {
+  @IsInt()
+  orgId!: number;
+
+  @IsInt()
+  gameId!: number;
+
+  @IsOptional()
+  @IsInt()
+  uexItemId?: number;
+
+  @IsOptional()
+  @IsInt()
+  locationId?: number;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  activeOnly?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  offset?: number;
+}
+
+export class OrgInventorySummaryDto {
+  orgId!: number;
+  gameId!: number;
+  totalItems!: number;
+  uniqueItems!: number;
+  locationCount!: number;
+  lastUpdated!: Date;
+}

--- a/backend/src/modules/org-inventory/entities/org-inventory-item.entity.ts
+++ b/backend/src/modules/org-inventory/entities/org-inventory-item.entity.ts
@@ -1,0 +1,101 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/user.entity';
+import { Game } from '../../games/game.entity';
+import { UexItem } from '../../uex/entities/uex-item.entity';
+import { Location } from '../../locations/entities/location.entity';
+import { Organization } from '../../organizations/organization.entity';
+
+@Entity('org_inventory_items')
+@Index('idx_org_inv_org_game', ['orgId', 'gameId', 'deleted'], {
+  where: 'deleted = FALSE',
+})
+@Index('idx_org_inv_item', ['uexItemId'], {
+  where: 'deleted = FALSE',
+})
+@Index('idx_org_inv_location', ['locationId'], {
+  where: 'deleted = FALSE',
+})
+@Index('idx_org_inv_recent', ['orgId', 'dateModified'], {
+  where: 'deleted = FALSE',
+})
+@Index('idx_org_inv_active', ['orgId', 'active'], {
+  where: 'deleted = FALSE',
+})
+export class OrgInventoryItem {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'org_id', type: 'bigint' })
+  @Index()
+  orgId!: number;
+
+  @ManyToOne(() => Organization)
+  @JoinColumn({ name: 'org_id' })
+  org!: Organization;
+
+  @Column({ name: 'game_id', type: 'integer' })
+  @Index()
+  gameId!: number;
+
+  @ManyToOne(() => Game)
+  @JoinColumn({ name: 'game_id' })
+  game!: Game;
+
+  @Column({ name: 'uex_item_id', type: 'integer' })
+  @Index()
+  uexItemId!: number;
+
+  @ManyToOne(() => UexItem)
+  @JoinColumn({ name: 'uex_item_id', referencedColumnName: 'uexId' })
+  item!: UexItem;
+
+  @Column({ name: 'location_id', type: 'bigint' })
+  @Index()
+  locationId!: number;
+
+  @ManyToOne(() => Location)
+  @JoinColumn({ name: 'location_id' })
+  location!: Location;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  quantity!: number;
+
+  @Column({ type: 'text', nullable: true })
+  notes?: string;
+
+  @Column({ default: true })
+  active!: boolean;
+
+  @Column({ default: false })
+  @Index()
+  deleted!: boolean;
+
+  @CreateDateColumn({ name: 'date_added', type: 'timestamptz' })
+  dateAdded!: Date;
+
+  @UpdateDateColumn({ name: 'date_modified', type: 'timestamptz' })
+  dateModified!: Date;
+
+  @Column({ name: 'added_by', type: 'bigint' })
+  addedBy!: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'added_by' })
+  addedByUser!: User;
+
+  @Column({ name: 'modified_by', type: 'bigint' })
+  modifiedBy!: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'modified_by' })
+  modifiedByUser!: User;
+}

--- a/backend/src/modules/org-inventory/org-inventory.controller.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.ts
@@ -1,0 +1,153 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { OrgInventoryService } from './org-inventory.service';
+import {
+  CreateOrgInventoryItemDto,
+  UpdateOrgInventoryItemDto,
+  OrgInventorySearchDto,
+  OrgInventoryItemDto,
+  OrgInventorySummaryDto,
+} from './dto/org-inventory-item.dto';
+
+@Controller('org-inventory')
+@UseGuards(JwtAuthGuard)
+export class OrgInventoryController {
+  constructor(private readonly orgInventoryService: OrgInventoryService) {}
+
+  /**
+   * Create a new org inventory item
+   * POST /org-inventory
+   */
+  @Post()
+  async create(
+    @Request() req: any,
+    @Body() createDto: CreateOrgInventoryItemDto,
+  ): Promise<OrgInventoryItemDto> {
+    return this.orgInventoryService.create(req.user.userId, createDto);
+  }
+
+  /**
+   * Get inventory items for an org by game
+   * GET /org-inventory/org/:orgId/game/:gameId
+   */
+  @Get('org/:orgId/game/:gameId')
+  async findByOrgAndGame(
+    @Request() req: any,
+    @Param('orgId') orgId: string,
+    @Param('gameId') gameId: string,
+  ): Promise<OrgInventoryItemDto[]> {
+    return this.orgInventoryService.findByOrgAndGame(
+      req.user.userId,
+      parseInt(orgId, 10),
+      parseInt(gameId, 10),
+    );
+  }
+
+  /**
+   * Get a specific inventory item by ID
+   * GET /org-inventory/:id
+   */
+  @Get(':id')
+  async findById(
+    @Request() req: any,
+    @Param('id') id: string,
+  ): Promise<OrgInventoryItemDto> {
+    return this.orgInventoryService.findById(req.user.userId, id);
+  }
+
+  /**
+   * Update an inventory item
+   * PUT /org-inventory/:id
+   */
+  @Put(':id')
+  async update(
+    @Request() req: any,
+    @Param('id') id: string,
+    @Body() updateDto: UpdateOrgInventoryItemDto,
+  ): Promise<OrgInventoryItemDto> {
+    return this.orgInventoryService.update(req.user.userId, id, updateDto);
+  }
+
+  /**
+   * Delete an inventory item (soft delete)
+   * DELETE /org-inventory/:id
+   */
+  @Delete(':id')
+  async delete(@Request() req: any, @Param('id') id: string): Promise<void> {
+    return this.orgInventoryService.delete(req.user.userId, id);
+  }
+
+  /**
+   * Search inventory with filters
+   * GET /org-inventory/search
+   */
+  @Get('search')
+  async search(
+    @Request() req: any,
+    @Query() searchDto: OrgInventorySearchDto,
+  ): Promise<OrgInventoryItemDto[]> {
+    return this.orgInventoryService.search(req.user.userId, searchDto);
+  }
+
+  /**
+   * Get inventory summary for an org
+   * GET /org-inventory/org/:orgId/game/:gameId/summary
+   */
+  @Get('org/:orgId/game/:gameId/summary')
+  async getSummary(
+    @Request() req: any,
+    @Param('orgId') orgId: string,
+    @Param('gameId') gameId: string,
+  ): Promise<OrgInventorySummaryDto> {
+    return this.orgInventoryService.getSummary(
+      req.user.userId,
+      parseInt(orgId, 10),
+      parseInt(gameId, 10),
+    );
+  }
+
+  /**
+   * Get inventory by location
+   * GET /org-inventory/org/:orgId/location/:locationId
+   */
+  @Get('org/:orgId/location/:locationId')
+  async findByLocation(
+    @Request() req: any,
+    @Param('orgId') orgId: string,
+    @Param('locationId') locationId: string,
+  ): Promise<OrgInventoryItemDto[]> {
+    return this.orgInventoryService.findByLocation(
+      req.user.userId,
+      parseInt(orgId, 10),
+      parseInt(locationId, 10),
+    );
+  }
+
+  /**
+   * Get inventory by UEX item
+   * GET /org-inventory/org/:orgId/item/:uexItemId
+   */
+  @Get('org/:orgId/item/:uexItemId')
+  async findByUexItem(
+    @Request() req: any,
+    @Param('orgId') orgId: string,
+    @Param('uexItemId') uexItemId: string,
+  ): Promise<OrgInventoryItemDto[]> {
+    return this.orgInventoryService.findByUexItem(
+      req.user.userId,
+      parseInt(orgId, 10),
+      parseInt(uexItemId, 10),
+    );
+  }
+}

--- a/backend/src/modules/org-inventory/org-inventory.module.ts
+++ b/backend/src/modules/org-inventory/org-inventory.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OrgInventoryItem } from './entities/org-inventory-item.entity';
+import { OrgInventoryService } from './org-inventory.service';
+import { OrgInventoryController } from './org-inventory.controller';
+import { OrgInventoryRepository } from './org-inventory.repository';
+import { PermissionsModule } from '../permissions/permissions.module';
+import { User } from '../users/user.entity';
+import { Game } from '../games/game.entity';
+import { UexItem } from '../uex/entities/uex-item.entity';
+import { Location } from '../locations/entities/location.entity';
+import { Organization } from '../organizations/organization.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      OrgInventoryItem,
+      User,
+      Game,
+      UexItem,
+      Location,
+      Organization,
+    ]),
+    PermissionsModule,
+  ],
+  controllers: [OrgInventoryController],
+  providers: [OrgInventoryService, OrgInventoryRepository],
+  exports: [OrgInventoryService, OrgInventoryRepository],
+})
+export class OrgInventoryModule {}

--- a/backend/src/modules/org-inventory/org-inventory.repository.ts
+++ b/backend/src/modules/org-inventory/org-inventory.repository.ts
@@ -1,0 +1,185 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { OrgInventoryItem } from './entities/org-inventory-item.entity';
+
+@Injectable()
+export class OrgInventoryRepository extends Repository<OrgInventoryItem> {
+  constructor(private dataSource: DataSource) {
+    super(OrgInventoryItem, dataSource.createEntityManager());
+  }
+
+  /**
+   * Find all active (non-deleted) inventory items for an org
+   */
+  async findByOrgId(orgId: number): Promise<OrgInventoryItem[]> {
+    return this.find({
+      where: { orgId, deleted: false },
+      relations: [
+        'item',
+        'location',
+        'game',
+        'org',
+        'addedByUser',
+        'modifiedByUser',
+      ],
+      order: { dateModified: 'DESC' },
+    });
+  }
+
+  /**
+   * Find inventory items by org and game
+   */
+  async findByOrgIdAndGameId(
+    orgId: number,
+    gameId: number,
+  ): Promise<OrgInventoryItem[]> {
+    return this.find({
+      where: { orgId, gameId, deleted: false },
+      relations: ['item', 'location', 'game', 'addedByUser', 'modifiedByUser'],
+      order: { dateModified: 'DESC' },
+    });
+  }
+
+  /**
+   * Find a specific item by ID (non-deleted only)
+   */
+  async findByIdNotDeleted(id: string): Promise<OrgInventoryItem | null> {
+    return this.findOne({
+      where: { id, deleted: false },
+      relations: [
+        'item',
+        'location',
+        'game',
+        'org',
+        'addedByUser',
+        'modifiedByUser',
+      ],
+    });
+  }
+
+  /**
+   * Find inventory items by location
+   */
+  async findByLocationId(locationId: number): Promise<OrgInventoryItem[]> {
+    return this.find({
+      where: { locationId, deleted: false },
+      relations: [
+        'item',
+        'location',
+        'game',
+        'org',
+        'addedByUser',
+        'modifiedByUser',
+      ],
+      order: { dateModified: 'DESC' },
+    });
+  }
+
+  /**
+   * Find inventory items by UEX item ID
+   */
+  async findByUexItemId(
+    orgId: number,
+    uexItemId: number,
+  ): Promise<OrgInventoryItem[]> {
+    return this.find({
+      where: { orgId, uexItemId, deleted: false },
+      relations: ['item', 'location', 'game', 'addedByUser', 'modifiedByUser'],
+      order: { dateModified: 'DESC' },
+    });
+  }
+
+  /**
+   * Soft delete an inventory item
+   */
+  async softDeleteItem(id: string, modifiedBy: number): Promise<boolean> {
+    const result = await this.update(
+      { id, deleted: false },
+      { deleted: true, modifiedBy },
+    );
+    return result.affected ? result.affected > 0 : false;
+  }
+
+  /**
+   * Get inventory summary for an org
+   */
+  async getOrgInventorySummary(
+    orgId: number,
+    gameId: number,
+  ): Promise<{
+    totalItems: number;
+    uniqueItems: number;
+    locationCount: number;
+    lastUpdated: Date | null;
+  }> {
+    const result = await this.createQueryBuilder('oii')
+      .select('COUNT(*)', 'totalItems')
+      .addSelect('COUNT(DISTINCT oii.uex_item_id)', 'uniqueItems')
+      .addSelect('COUNT(DISTINCT oii.location_id)', 'locationCount')
+      .addSelect('MAX(oii.date_modified)', 'lastUpdated')
+      .where('oii.org_id = :orgId', { orgId })
+      .andWhere('oii.game_id = :gameId', { gameId })
+      .andWhere('oii.deleted = false')
+      .andWhere('oii.active = true')
+      .getRawOne();
+
+    return {
+      totalItems: parseInt(result.totalItems, 10) || 0,
+      uniqueItems: parseInt(result.uniqueItems, 10) || 0,
+      locationCount: parseInt(result.locationCount, 10) || 0,
+      lastUpdated: result.lastUpdated || null,
+    };
+  }
+
+  /**
+   * Search inventory items with filters
+   */
+  async searchInventory(filters: {
+    orgId: number;
+    gameId: number;
+    uexItemId?: number;
+    locationId?: number;
+    activeOnly?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<OrgInventoryItem[]> {
+    const query = this.createQueryBuilder('oii')
+      .leftJoinAndSelect('oii.item', 'item')
+      .leftJoinAndSelect('oii.location', 'location')
+      .leftJoinAndSelect('oii.game', 'game')
+      .leftJoinAndSelect('oii.org', 'org')
+      .leftJoinAndSelect('oii.addedByUser', 'addedBy')
+      .leftJoinAndSelect('oii.modifiedByUser', 'modifiedBy')
+      .where('oii.org_id = :orgId', { orgId: filters.orgId })
+      .andWhere('oii.game_id = :gameId', { gameId: filters.gameId })
+      .andWhere('oii.deleted = false');
+
+    if (filters.uexItemId) {
+      query.andWhere('oii.uex_item_id = :uexItemId', {
+        uexItemId: filters.uexItemId,
+      });
+    }
+
+    if (filters.locationId) {
+      query.andWhere('oii.location_id = :locationId', {
+        locationId: filters.locationId,
+      });
+    }
+
+    if (filters.activeOnly) {
+      query.andWhere('oii.active = true');
+    }
+
+    query.orderBy('oii.date_modified', 'DESC');
+
+    if (filters.limit) {
+      query.limit(filters.limit);
+    }
+
+    if (filters.offset) {
+      query.offset(filters.offset);
+    }
+
+    return query.getMany();
+  }
+}

--- a/backend/src/modules/org-inventory/org-inventory.service.spec.ts
+++ b/backend/src/modules/org-inventory/org-inventory.service.spec.ts
@@ -1,0 +1,370 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { OrgInventoryService } from './org-inventory.service';
+import { OrgInventoryRepository } from './org-inventory.repository';
+import { PermissionsService } from '../permissions/permissions.service';
+import { OrgInventoryItem } from './entities/org-inventory-item.entity';
+import {
+  CreateOrgInventoryItemDto,
+  UpdateOrgInventoryItemDto,
+  OrgInventorySearchDto,
+} from './dto/org-inventory-item.dto';
+
+describe('OrgInventoryService', () => {
+  let service: OrgInventoryService;
+  let repository: OrgInventoryRepository;
+  let permissionsService: PermissionsService;
+
+  const mockOrgInventoryItem: OrgInventoryItem = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    orgId: 1,
+    gameId: 1,
+    uexItemId: 100,
+    locationId: 200,
+    quantity: 10.5,
+    notes: 'Test org item',
+    active: true,
+    deleted: false,
+    dateAdded: new Date(),
+    dateModified: new Date(),
+    addedBy: 1,
+    modifiedBy: 1,
+    org: { id: 1, name: 'Test Org' } as any,
+    game: { id: 1, name: 'Star Citizen' } as any,
+    item: { name: 'Test Item' } as any,
+    location: { displayName: 'Test Location' } as any,
+    addedByUser: { username: 'testuser' } as any,
+    modifiedByUser: { username: 'testuser' } as any,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrgInventoryService,
+        {
+          provide: OrgInventoryRepository,
+          useValue: {
+            findByOrgIdAndGameId: jest.fn(),
+            findByIdNotDeleted: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            softDeleteItem: jest.fn(),
+            searchInventory: jest.fn(),
+            getOrgInventorySummary: jest.fn(),
+            findByLocationId: jest.fn(),
+            findByUexItemId: jest.fn(),
+          },
+        },
+        {
+          provide: PermissionsService,
+          useValue: {
+            hasPermission: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<OrgInventoryService>(OrgInventoryService);
+    repository = module.get<OrgInventoryRepository>(OrgInventoryRepository);
+    permissionsService = module.get<PermissionsService>(PermissionsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const createDto: CreateOrgInventoryItemDto = {
+      orgId: 1,
+      gameId: 1,
+      uexItemId: 100,
+      locationId: 200,
+      quantity: 10.5,
+      notes: 'Test notes',
+    };
+
+    it('should create org inventory item with manage permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest.spyOn(repository, 'create').mockReturnValue(mockOrgInventoryItem);
+      jest.spyOn(repository, 'save').mockResolvedValue(mockOrgInventoryItem);
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+
+      const result = await service.create(1, createDto);
+
+      expect(result.id).toBe(mockOrgInventoryItem.id);
+      expect(permissionsService.hasPermission).toHaveBeenCalledWith(
+        1,
+        1,
+        'inventory.manage',
+      );
+      expect(repository.create).toHaveBeenCalledWith({
+        ...createDto,
+        addedBy: 1,
+        modifiedBy: 1,
+        active: true,
+        deleted: false,
+      });
+    });
+
+    it('should throw ForbiddenException without manage permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(service.create(1, createDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findByOrgAndGame', () => {
+    it('should return org inventory items with view permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'findByOrgIdAndGameId')
+        .mockResolvedValue([mockOrgInventoryItem]);
+
+      const result = await service.findByOrgAndGame(1, 1, 1);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockOrgInventoryItem.id);
+      expect(permissionsService.hasPermission).toHaveBeenCalledWith(
+        1,
+        1,
+        'inventory.view',
+      );
+    });
+
+    it('should throw ForbiddenException without view permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(service.findByOrgAndGame(1, 1, 1)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('findById', () => {
+    it('should return org inventory item by id', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+
+      const result = await service.findById(1, mockOrgInventoryItem.id);
+
+      expect(result.id).toBe(mockOrgInventoryItem.id);
+      expect(repository.findByIdNotDeleted).toHaveBeenCalledWith(
+        mockOrgInventoryItem.id,
+      );
+    });
+
+    it('should throw NotFoundException if item not found', async () => {
+      jest.spyOn(repository, 'findByIdNotDeleted').mockResolvedValue(null);
+
+      await expect(service.findById(1, 'nonexistent-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException without view permission', async () => {
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(
+        service.findById(1, mockOrgInventoryItem.id),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('update', () => {
+    const updateDto: UpdateOrgInventoryItemDto = {
+      quantity: 20,
+      notes: 'Updated notes',
+    };
+
+    it('should update org inventory item with manage permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+      const updatedItem = { ...mockOrgInventoryItem, ...updateDto };
+      jest.spyOn(repository, 'save').mockResolvedValue(updatedItem);
+
+      const result = await service.update(
+        1,
+        mockOrgInventoryItem.id,
+        updateDto,
+      );
+
+      expect(result.quantity).toBe(20);
+      expect(result.notes).toBe('Updated notes');
+      expect(permissionsService.hasPermission).toHaveBeenCalledWith(
+        1,
+        1,
+        'inventory.manage',
+      );
+    });
+
+    it('should throw NotFoundException if item not found', async () => {
+      jest.spyOn(repository, 'findByIdNotDeleted').mockResolvedValue(null);
+
+      await expect(
+        service.update(1, 'nonexistent-id', updateDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException without manage permission', async () => {
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(
+        service.update(1, mockOrgInventoryItem.id, updateDto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('delete', () => {
+    it('should soft delete org inventory item with manage permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+      jest.spyOn(repository, 'softDeleteItem').mockResolvedValue(true);
+
+      await service.delete(1, mockOrgInventoryItem.id);
+
+      expect(repository.softDeleteItem).toHaveBeenCalledWith(
+        mockOrgInventoryItem.id,
+        1,
+      );
+    });
+
+    it('should throw NotFoundException if item not found', async () => {
+      jest.spyOn(repository, 'findByIdNotDeleted').mockResolvedValue(null);
+
+      await expect(service.delete(1, 'nonexistent-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException without manage permission', async () => {
+      jest
+        .spyOn(repository, 'findByIdNotDeleted')
+        .mockResolvedValue(mockOrgInventoryItem);
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(service.delete(1, mockOrgInventoryItem.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('search', () => {
+    const searchDto: OrgInventorySearchDto = {
+      orgId: 1,
+      gameId: 1,
+      activeOnly: true,
+    };
+
+    it('should search org inventory items with view permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'searchInventory')
+        .mockResolvedValue([mockOrgInventoryItem]);
+
+      const result = await service.search(1, searchDto);
+
+      expect(result).toHaveLength(1);
+      expect(repository.searchInventory).toHaveBeenCalledWith({
+        orgId: 1,
+        gameId: 1,
+        activeOnly: true,
+        limit: 100,
+        offset: 0,
+        locationId: undefined,
+        uexItemId: undefined,
+      });
+    });
+
+    it('should throw ForbiddenException without view permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(service.search(1, searchDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should return org inventory summary with view permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest.spyOn(repository, 'getOrgInventorySummary').mockResolvedValue({
+        totalItems: 10,
+        uniqueItems: 5,
+        locationCount: 3,
+        lastUpdated: new Date(),
+      });
+
+      const result = await service.getSummary(1, 1, 1);
+
+      expect(result.totalItems).toBe(10);
+      expect(result.uniqueItems).toBe(5);
+      expect(result.locationCount).toBe(3);
+    });
+
+    it('should throw ForbiddenException without view permission', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(service.getSummary(1, 1, 1)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('findByLocation', () => {
+    it('should return org inventory items by location', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'findByLocationId')
+        .mockResolvedValue([mockOrgInventoryItem]);
+
+      const result = await service.findByLocation(1, 1, 200);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].locationId).toBe(200);
+    });
+
+    it('should filter out items from other orgs', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      const otherOrgItem = { ...mockOrgInventoryItem, orgId: 2 };
+      jest
+        .spyOn(repository, 'findByLocationId')
+        .mockResolvedValue([mockOrgInventoryItem, otherOrgItem]);
+
+      const result = await service.findByLocation(1, 1, 200);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].orgId).toBe(1);
+    });
+  });
+
+  describe('findByUexItem', () => {
+    it('should return org inventory items by UEX item', async () => {
+      jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
+      jest
+        .spyOn(repository, 'findByUexItemId')
+        .mockResolvedValue([mockOrgInventoryItem]);
+
+      const result = await service.findByUexItem(1, 1, 100);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].uexItemId).toBe(100);
+    });
+  });
+});

--- a/backend/src/modules/org-inventory/org-inventory.service.ts
+++ b/backend/src/modules/org-inventory/org-inventory.service.ts
@@ -1,0 +1,284 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { OrgInventoryRepository } from './org-inventory.repository';
+import { PermissionsService } from '../permissions/permissions.service';
+import { OrgInventoryItem } from './entities/org-inventory-item.entity';
+import {
+  CreateOrgInventoryItemDto,
+  UpdateOrgInventoryItemDto,
+  OrgInventorySearchDto,
+  OrgInventorySummaryDto,
+  OrgInventoryItemDto,
+} from './dto/org-inventory-item.dto';
+
+@Injectable()
+export class OrgInventoryService {
+  constructor(
+    private readonly orgInventoryRepository: OrgInventoryRepository,
+    private readonly permissionsService: PermissionsService,
+  ) {}
+
+  /**
+   * Verify user has permission to manage org inventory
+   */
+  private async verifyInventoryPermission(
+    userId: number,
+    orgId: number,
+    action: 'view' | 'manage',
+  ): Promise<void> {
+    const permission =
+      action === 'view' ? 'inventory.view' : 'inventory.manage';
+
+    const hasPermission = await this.permissionsService.hasPermission(
+      userId,
+      orgId,
+      permission,
+    );
+
+    if (!hasPermission) {
+      throw new ForbiddenException(
+        `You do not have permission to ${action} inventory for this organization`,
+      );
+    }
+  }
+
+  /**
+   * Convert entity to DTO
+   */
+  private toDto(entity: OrgInventoryItem): OrgInventoryItemDto {
+    return {
+      id: entity.id,
+      orgId: entity.orgId,
+      gameId: entity.gameId,
+      uexItemId: entity.uexItemId,
+      locationId: entity.locationId,
+      quantity: entity.quantity,
+      notes: entity.notes,
+      active: entity.active,
+      dateAdded: entity.dateAdded,
+      dateModified: entity.dateModified,
+      addedBy: entity.addedBy,
+      modifiedBy: entity.modifiedBy,
+      itemName: entity.item?.name,
+      locationName: entity.location?.displayName,
+      orgName: entity.org?.name,
+      addedByUsername: entity.addedByUser?.username,
+      modifiedByUsername: entity.modifiedByUser?.username,
+    };
+  }
+
+  /**
+   * Create a new org inventory item
+   */
+  async create(
+    userId: number,
+    dto: CreateOrgInventoryItemDto,
+  ): Promise<OrgInventoryItemDto> {
+    await this.verifyInventoryPermission(userId, dto.orgId, 'manage');
+
+    const item = this.orgInventoryRepository.create({
+      ...dto,
+      addedBy: userId,
+      modifiedBy: userId,
+      active: true,
+      deleted: false,
+    });
+
+    const saved = await this.orgInventoryRepository.save(item);
+    const loaded = await this.orgInventoryRepository.findByIdNotDeleted(
+      saved.id,
+    );
+
+    if (!loaded) {
+      throw new NotFoundException('Failed to load created inventory item');
+    }
+
+    return this.toDto(loaded);
+  }
+
+  /**
+   * Get all inventory items for an org (by game)
+   */
+  async findByOrgAndGame(
+    userId: number,
+    orgId: number,
+    gameId: number,
+  ): Promise<OrgInventoryItemDto[]> {
+    await this.verifyInventoryPermission(userId, orgId, 'view');
+
+    const items = await this.orgInventoryRepository.findByOrgIdAndGameId(
+      orgId,
+      gameId,
+    );
+    return items.map((item) => this.toDto(item));
+  }
+
+  /**
+   * Get a specific inventory item by ID
+   */
+  async findById(userId: number, id: string): Promise<OrgInventoryItemDto> {
+    const item = await this.orgInventoryRepository.findByIdNotDeleted(id);
+
+    if (!item) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    await this.verifyInventoryPermission(userId, item.orgId, 'view');
+
+    return this.toDto(item);
+  }
+
+  /**
+   * Update an inventory item
+   */
+  async update(
+    userId: number,
+    id: string,
+    dto: UpdateOrgInventoryItemDto,
+  ): Promise<OrgInventoryItemDto> {
+    const item = await this.orgInventoryRepository.findByIdNotDeleted(id);
+
+    if (!item) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    await this.verifyInventoryPermission(userId, item.orgId, 'manage');
+
+    // Update fields
+    if (dto.locationId !== undefined) {
+      item.locationId = dto.locationId;
+    }
+    if (dto.quantity !== undefined) {
+      item.quantity = dto.quantity;
+    }
+    if (dto.notes !== undefined) {
+      item.notes = dto.notes;
+    }
+    if (dto.active !== undefined) {
+      item.active = dto.active;
+    }
+
+    item.modifiedBy = userId;
+
+    const saved = await this.orgInventoryRepository.save(item);
+    const loaded = await this.orgInventoryRepository.findByIdNotDeleted(
+      saved.id,
+    );
+
+    if (!loaded) {
+      throw new NotFoundException('Failed to load updated inventory item');
+    }
+
+    return this.toDto(loaded);
+  }
+
+  /**
+   * Soft delete an inventory item
+   */
+  async delete(userId: number, id: string): Promise<void> {
+    const item = await this.orgInventoryRepository.findByIdNotDeleted(id);
+
+    if (!item) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    await this.verifyInventoryPermission(userId, item.orgId, 'manage');
+
+    const deleted = await this.orgInventoryRepository.softDeleteItem(
+      id,
+      userId,
+    );
+
+    if (!deleted) {
+      throw new BadRequestException('Failed to delete inventory item');
+    }
+  }
+
+  /**
+   * Search inventory with filters
+   */
+  async search(
+    userId: number,
+    searchDto: OrgInventorySearchDto,
+  ): Promise<OrgInventoryItemDto[]> {
+    await this.verifyInventoryPermission(userId, searchDto.orgId, 'view');
+
+    const items = await this.orgInventoryRepository.searchInventory({
+      orgId: searchDto.orgId,
+      gameId: searchDto.gameId,
+      uexItemId: searchDto.uexItemId,
+      locationId: searchDto.locationId,
+      activeOnly: searchDto.activeOnly,
+      limit: searchDto.limit || 100,
+      offset: searchDto.offset || 0,
+    });
+
+    return items.map((item) => this.toDto(item));
+  }
+
+  /**
+   * Get inventory summary for an org
+   */
+  async getSummary(
+    userId: number,
+    orgId: number,
+    gameId: number,
+  ): Promise<OrgInventorySummaryDto> {
+    await this.verifyInventoryPermission(userId, orgId, 'view');
+
+    const summary = await this.orgInventoryRepository.getOrgInventorySummary(
+      orgId,
+      gameId,
+    );
+
+    return {
+      orgId,
+      gameId,
+      totalItems: summary.totalItems,
+      uniqueItems: summary.uniqueItems,
+      locationCount: summary.locationCount,
+      lastUpdated: summary.lastUpdated!,
+    };
+  }
+
+  /**
+   * Get inventory by location
+   */
+  async findByLocation(
+    userId: number,
+    orgId: number,
+    locationId: number,
+  ): Promise<OrgInventoryItemDto[]> {
+    await this.verifyInventoryPermission(userId, orgId, 'view');
+
+    const items =
+      await this.orgInventoryRepository.findByLocationId(locationId);
+
+    // Filter to ensure only items from this org are returned
+    const orgItems = items.filter((item) => item.orgId === orgId);
+
+    return orgItems.map((item) => this.toDto(item));
+  }
+
+  /**
+   * Get inventory by UEX item
+   */
+  async findByUexItem(
+    userId: number,
+    orgId: number,
+    uexItemId: number,
+  ): Promise<OrgInventoryItemDto[]> {
+    await this.verifyInventoryPermission(userId, orgId, 'view');
+
+    const items = await this.orgInventoryRepository.findByUexItemId(
+      orgId,
+      uexItemId,
+    );
+
+    return items.map((item) => this.toDto(item));
+  }
+}


### PR DESCRIPTION
Implements organization-owned inventory system distinct from user inventory.

Database Schema:

- Create org_inventory_items table with soft-delete support

- Add optimized indexes for org/game/location/item queries

- Quantity validation and auto-update timestamp triggers

- Full FK relationships to orgs, games, items, locations, users

API Implementation:

- OrgInventoryRepository with soft-delete pattern

- OrgInventoryService with permission checks (inventory.view/manage)

- OrgInventoryController with JWT auth and RESTful endpoints

- Full CRUD operations with org ownership validation

- Summary statistics and search/filter capabilities

DTOs:

- CreateOrgInventoryItemDto with validation

- UpdateOrgInventoryItemDto with partial updates

- OrgInventorySearchDto with filters

- OrgInventorySummaryDto for statistics

Testing:

- 20 comprehensive unit tests covering all service methods

- Permission check validation

- Error scenario coverage (NotFoundException, ForbiddenException)

- CRUD operation tests with mocked dependencies

Documentation:

- Org vs user inventory architecture guide

- Future transfer workflow design (user→org, org→user)

- Permission model and API endpoint documentation

Resolves #19