### PR TITLE
feat: complete inventory dashboard portlet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,70 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
+## Project Overview
 
-- Monorepo managed with pnpm + Turbo. Backend: `backend/` (NestJS app in `src/`, migrations in `src/migrations`, tests in `test/`). Frontend: `frontend/` (React/Vite code in `src/`).
-- Shared tooling at root (`turbo.json`, `pnpm-workspace.yaml`, `tsconfig.json`, husky hooks); infra assets live in `docker-compose.yml`, `k8s/`, and package `Dockerfile`s.
+- Station is a pnpm workspace monorepo for gaming guild/organization management with a NestJS backend and React frontend.
+- RBAC uses JSONB permissions, JWT auth with refresh rotation, and Redis caching with in-memory fallback.
+- Public repository: https://github.com/GitAddRemote/station
+
+## Project Structure & Setup
+
+- Monorepo managed with pnpm + Turbo. Backend: `backend/` (NestJS in `src/`, migrations in `src/migrations`, tests in `test/`). Frontend: `frontend/` (React/Vite in `src/`).
+- Shared tooling at root (`turbo.json`, `pnpm-workspace.yaml`, `tsconfig.json`, husky hooks); infra in `docker-compose.yml`, `k8s/`, and package `Dockerfile`s.
 - Copy env templates before running services: `backend/.env.example`, `frontend/.env.example`.
 
-## Build, Test, and Development Commands
+## Development & Build Commands
 
 - Install once at root: `pnpm install`.
-- Develop both apps with `pnpm dev`; scope to a package via `pnpm --filter backend dev` or `pnpm --filter frontend dev`.
-- Build with `pnpm build` or scoped `pnpm --filter <pkg> build`.
-- Tests: `pnpm test` (all), `pnpm --filter backend test`, `pnpm --filter backend test:e2e`, `pnpm --filter backend test:cov`.
-- Lint/format/typecheck: `pnpm lint`, `pnpm format`, `pnpm typecheck`. Husky + lint-staged auto-format backend TS on commit.
+- Run both apps: `pnpm dev`. Scoped dev: `pnpm dev:backend` (http://localhost:3001) and `pnpm dev:frontend` (http://localhost:5173).
+- Build: `pnpm build` or `pnpm --filter <pkg> build`.
 - Local data stack: `docker-compose up -d` (Postgres 5433, Redis 6379); run `pnpm --filter backend migration:run` after services are healthy.
 
-## Coding Style & Naming Conventions
+## Testing & Quality
 
-- TypeScript everywhere; follow ESLint configs (`backend/eslint.config.js`, `frontend/.eslintrc.cjs`) and Prettier defaults (2-space indent).
-- Naming: `camelCase` for vars/functions, `PascalCase` for classes/components, `SCREAMING_SNAKE_CASE` for constants/envs. Backend follows Nest patterns (`*.module.ts`, `*.service.ts`, `*.controller.ts`); React components live one per file.
+- Backend tests from `backend/`: `pnpm test`, `pnpm test:e2e`, `pnpm test:watch`, `pnpm test:cov`. Root: `pnpm test`.
+- Lint/format/typecheck: `pnpm lint`, `pnpm format`, `pnpm typecheck`.
+- E2E requires PostgreSQL running (`docker-compose up -d database`); tests drop/recreate schema (`synchronize: true`, `dropSchema: true`) and run serially.
+
+## Coding Style & Code Quality
+
+- TypeScript everywhere; ESLint configs (`backend/eslint.config.js`, `frontend/.eslintrc.cjs`) and Prettier defaults (2-space indent).
+- Naming: `camelCase` vars/functions, `PascalCase` classes/components, `SCREAMING_SNAKE_CASE` constants/envs. Backend follows Nest patterns (`*.module.ts`, `*.service.ts`, `*.controller.ts`); React components live one per file.
+- Code quality standards: prioritize scalability, industry best practices, performance (queries/caching/complexity), and modern TS/JS features and patterns.
 - Prefer typed DTOs/interfaces; use async/await with explicit HTTP exceptions and validation.
 
-## Testing Guidelines
+## Architecture Notes
 
-- Backend: Jest specs under `backend/test` or alongside code as `*.spec.ts`; E2E uses `backend/test/jest-e2e.json`. Cover new endpoints/services and add E2E for auth or database flows.
-- Frontend: use React Testing Library; place specs next to components as `*.test.tsx`.
-- Aim for passing coverage check via `pnpm --filter backend test:cov`; mock external calls in unit tests and reserve real integrations for E2E.
+- Backend modules: `auth`, `users`, `organizations`, `roles`, `user-organization-roles`, `permissions`, `audit-logs`; each with module/controller/service/entity/dto/guards.
+- Database: PostgreSQL + TypeORM manual migrations (no prod sync). Schema includes users, roles, organizations, user_organization_role (composite indexes), audit_log, refresh_tokens, password_resets. Permissions stored in JSONB.
+- Caching: Redis default (`REDIS_HOST:6379`), automatic in-memory fallback; tests force in-memory via `USE_REDIS_CACHE=false`; default TTL 5 minutes. Cached: organization members, aggregated permissions.
+- Auth flow: register → login → protected routes with bearer access token (15m) + refresh token (7d) rotation; refresh endpoint issues new pair; logout revokes refresh tokens. Guards: `JwtAuthGuard`, `LocalAuthGuard`, `RefreshTokenAuthGuard`. Passwords hashed with bcrypt (10 rounds), JWT signed with `JWT_SECRET`.
+- Audit logging: use `AuditLogsService` to record actions with resource metadata.
 
-## Commit & Pull Request Guidelines
+## Environment Configuration
 
-- Use concise, imperative commits; conventional prefixes (`feat:`, `fix:`, `ci:`) match existing history. One change-set per commit.
-- Before a PR: ensure `pnpm lint`, `pnpm test`, and relevant builds succeed; call out migrations or breaking changes.
-- PRs should include a short summary, linked issue, and testing notes. Add screenshots/GIFs for UI updates and flag security-sensitive changes (auth, tokens, RBAC).
+- Backend `.env` essentials: `DATABASE_HOST=localhost`, `DATABASE_PORT=5433`, `DATABASE_USER=stationDbUser`, `DATABASE_PASSWORD=stationDbPassword1`, `DATABASE_NAME=stationDb`, `JWT_SECRET`, `REDIS_HOST=localhost`, `REDIS_PORT=6379`, `PORT=3001`, `APP_NAME=STATION BACKEND`, `USE_REDIS_CACHE=true` (false for tests). `.env.test` mirrors `.env` with `USE_REDIS_CACHE=false`.
 
-## Security & Configuration Tips
+## Database & Migration Safety
 
-- Keep secrets out of Git; rely on the env examples and local overrides. Rotate `JWT_SECRET` and database creds outside local dev.
-- Confirm CORS + HTTPS settings before deploying. For data debugging, prefer `docker-compose logs -f` and `pnpm --filter backend migration:revert` instead of manual DB edits.
+- Commands from `backend/`: `pnpm migration:create src/migrations/YourMigrationName`, `pnpm migration:run`, `pnpm migration:revert`, `pnpm db:backup`, `pnpm db:health-check`, `pnpm seed`. Always create a backup before production migrations.
+- Every production migration needs working `up`/`down`, tested rollback (`migration:revert`), pre-migration backup, post-migration health check, and alignment with `backend/src/migrations/templates/PRE_MIGRATION_CHECKLIST.md` plus rollback decision tree in `backend/docs/database/migrations.md`. Use template `backend/src/migrations/templates/migration-template.ts`.
+
+## Husky & Tooling
+
+- lint-staged runs on commit: backend ESLint + Prettier; root Prettier on JSON/MD. Prefer fixing hooks rather than bypassing; `git commit --no-verify` only if necessary.
+- Turbo coordinates builds/tests; use `pnpm --filter <package>` for scoped tasks.
+
+## Commit Workflow
+
+- Never commit code directly. Provide git commands only, formatted for terminal execution with `-m` per line, blank lines via `-m ""`, and conventional first-line type (feat/fix/docs/test/refactor/perf/chore). Group related changes with bullet points; no attribution or AI notices. User executes commands manually.
+
+## Common Gotchas
+
+- Ensure database running (`docker-compose up -d database`) before app/tests; port defaults: backend 3001, frontend 5173, Postgres 5433.
+- Migration errors: test rollback early; prod uses `migrationsRun: false`.
+- Redis connection warnings expected in tests due to in-memory fallback.
+- Requires pnpm 8+ and Node 18+ (see package engines).
+
+## Attribution
+
+- Never include AI attribution in code, comments, or commit messages. Code should read as human-written.

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -9,6 +9,23 @@ import { RefreshToken } from './modules/auth/refresh-token.entity';
 import { PasswordReset } from './modules/auth/password-reset.entity';
 import { AuditLog } from './modules/audit-logs/audit-log.entity';
 import { Game } from './modules/games/game.entity';
+import { Location } from './modules/locations/entities/location.entity';
+import { UserInventoryItem } from './modules/user-inventory/entities/user-inventory-item.entity';
+import { InventoryAuditLog } from './modules/user-inventory/entities/inventory-audit-log.entity';
+import { OrgInventoryItem } from './modules/org-inventory/entities/org-inventory-item.entity';
+import { UexItem } from './modules/uex/entities/uex-item.entity';
+import { UexCategory } from './modules/uex/entities/uex-category.entity';
+import { UexCompany } from './modules/uex/entities/uex-company.entity';
+import { UexStarSystem } from './modules/uex/entities/uex-star-system.entity';
+import { UexPlanet } from './modules/uex/entities/uex-planet.entity';
+import { UexMoon } from './modules/uex/entities/uex-moon.entity';
+import { UexSpaceStation } from './modules/uex/entities/uex-space-station.entity';
+import { UexCity } from './modules/uex/entities/uex-city.entity';
+import { UexOutpost } from './modules/uex/entities/uex-outpost.entity';
+import { UexPoi } from './modules/uex/entities/uex-poi.entity';
+import { UexSyncState } from './modules/uex-sync/uex-sync-state.entity';
+import { UexSyncConfig } from './modules/uex-sync/uex-sync-config.entity';
+
 import { CreateUsersTable1716956654528 } from './migrations/1716956654528-CreateUsersTable';
 import { CreateOrganizationsRolesAndJunctionTable1730841000000 } from './migrations/1730841000000-CreateOrganizationsRolesAndJunctionTable';
 import { CreateAuditLogsTable1730900000000 } from './migrations/1730900000000-CreateAuditLogsTable';
@@ -17,6 +34,19 @@ import { AddUserProfileFields1732000000000 } from './migrations/1732000000000-Ad
 import { CreatePasswordResetsTable1732050000000 } from './migrations/1732050000000-CreatePasswordResetsTable';
 import { CreateGamesTable1733174400000 } from './migrations/1733174400000-CreateGamesTable';
 import { AddGameIdToOrganizations1733174500000 } from './migrations/1733174500000-AddGameIdToOrganizations';
+import { AddIsSystemUserColumn1764791773398 } from './migrations/1764791773398-AddIsSystemUserColumn';
+import { SeedSystemUser1764791795973 } from './migrations/1764791795973-SeedSystemUser';
+import { CreateUexBaseTables1764802822073 } from './migrations/1764802822073-CreateUexBaseTables';
+import { CreateUexItemsTable1764802975691 } from './migrations/1764802975691-CreateUexItemsTable';
+import { CreateUexLocationTables1764803020274 } from './migrations/1764803020274-CreateUexLocationTables';
+import { AddUexSyncStateTables1764812815840 } from './migrations/1764812815840-AddUexSyncStateTables';
+import { CreateLocationsTable1764949892544 } from './migrations/1764949892544-CreateLocationsTable';
+import { CreateUserInventoryItemsTable1764950546163 } from './migrations/1764950546163-CreateUserInventoryItemsTable';
+import { CreateInventoryAuditLogTable1764950688227 } from './migrations/1764950688227-CreateInventoryAuditLogTable';
+import { AddAutoUnshareInventoryTrigger1764950720430 } from './migrations/1764950720430-AddAutoUnshareInventoryTrigger';
+import { AddOrgInventorySummaryView1764950757207 } from './migrations/1764950757207-AddOrgInventorySummaryView';
+import { SeedInventoryManagerRole1764961461064 } from './migrations/1764961461064-SeedInventoryManagerRole';
+import { CreateOrgInventoryItemsTable1764964935270 } from './migrations/1764964935270-CreateOrgInventoryItemsTable';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
@@ -34,16 +64,54 @@ export const AppDataSource = new DataSource({
     PasswordReset,
     AuditLog,
     Game,
+    Location,
+    UserInventoryItem,
+    InventoryAuditLog,
+    OrgInventoryItem,
+    UexItem,
+    UexCategory,
+    UexCompany,
+    UexStarSystem,
+    UexPlanet,
+    UexMoon,
+    UexSpaceStation,
+    UexCity,
+    UexOutpost,
+    UexPoi,
+    UexSyncState,
+    UexSyncConfig,
   ],
   migrations: [
+    // Core user/org/auth setup
     CreateUsersTable1716956654528,
+    AddIsSystemUserColumn1764791773398,
+    SeedSystemUser1764791795973,
     CreateOrganizationsRolesAndJunctionTable1730841000000,
     CreateAuditLogsTable1730900000000,
     CreateRefreshTokenTable1731715200000,
     AddUserProfileFields1732000000000,
     CreatePasswordResetsTable1732050000000,
+
+    // Games must come before locations
     CreateGamesTable1733174400000,
     AddGameIdToOrganizations1733174500000,
+
+    // UEX tables (base entities for items/locations)
+    CreateUexBaseTables1764802822073,
+    CreateUexItemsTable1764802975691,
+    CreateUexLocationTables1764803020274,
+    AddUexSyncStateTables1764812815840,
+
+    // Locations (depends on games + UEX tables)
+    CreateLocationsTable1764949892544,
+
+    // Inventory (depends on locations, games, UEX items)
+    CreateUserInventoryItemsTable1764950546163,
+    CreateInventoryAuditLogTable1764950688227,
+    AddAutoUnshareInventoryTrigger1764950720430,
+    AddOrgInventorySummaryView1764950757207,
+    SeedInventoryManagerRole1764961461064,
+    CreateOrgInventoryItemsTable1764964935270,
   ],
   synchronize: false,
 });

--- a/backend/src/migrations/1733174400000-CreateGamesTable.ts
+++ b/backend/src/migrations/1733174400000-CreateGamesTable.ts
@@ -25,7 +25,7 @@ export class CreateGamesTable1733174400000 implements MigrationInterface {
     // Create games table
     await queryRunner.createTable(
       new Table({
-        name: 'game',
+        name: 'games',
         columns: [
           {
             name: 'id',
@@ -78,25 +78,25 @@ export class CreateGamesTable1733174400000 implements MigrationInterface {
 
     // Create index on active column for efficient queries
     await queryRunner.createIndex(
-      'game',
+      'games',
       new TableIndex({
-        name: 'IDX_game_active',
+        name: 'IDX_games_active',
         columnNames: ['active'],
       }),
     );
 
     // Create index on code column for lookups
     await queryRunner.createIndex(
-      'game',
+      'games',
       new TableIndex({
-        name: 'IDX_game_code',
+        name: 'IDX_games_code',
         columnNames: ['code'],
       }),
     );
 
     // Seed initial games
     await queryRunner.query(`
-      INSERT INTO "game" ("name", "code", "description", "active")
+      INSERT INTO "games" ("name", "code", "description", "active")
       VALUES
         ('Star Citizen', 'sc', 'Star Citizen is a multiplayer space trading and combat simulation game.', true),
         ('Squadron 42', 'sq42', 'Squadron 42 is a single-player space combat game set in the Star Citizen universe.', true)
@@ -108,10 +108,10 @@ export class CreateGamesTable1733174400000 implements MigrationInterface {
    */
   public async down(queryRunner: QueryRunner): Promise<void> {
     // Drop indexes
-    await queryRunner.dropIndex('game', 'IDX_game_code');
-    await queryRunner.dropIndex('game', 'IDX_game_active');
+    await queryRunner.dropIndex('games', 'IDX_games_code');
+    await queryRunner.dropIndex('games', 'IDX_games_active');
 
     // Drop table
-    await queryRunner.dropTable('game');
+    await queryRunner.dropTable('games');
   }
 }

--- a/backend/src/migrations/1733174500000-AddGameIdToOrganizations.ts
+++ b/backend/src/migrations/1733174500000-AddGameIdToOrganizations.ts
@@ -64,7 +64,7 @@ export class AddGameIdToOrganizations1733174500000
       new TableForeignKey({
         name: 'FK_organization_game',
         columnNames: ['game_id'],
-        referencedTableName: 'game',
+        referencedTableName: 'games',
         referencedColumnNames: ['id'],
         onDelete: 'RESTRICT',
         onUpdate: 'CASCADE',

--- a/backend/src/modules/games/game.entity.ts
+++ b/backend/src/modules/games/game.entity.ts
@@ -7,7 +7,7 @@ import {
   Index,
 } from 'typeorm';
 
-@Entity()
+@Entity({ name: 'games' })
 export class Game {
   @PrimaryGeneratedColumn()
   id!: number;
@@ -26,9 +26,9 @@ export class Game {
   @Index()
   active!: boolean;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 
-  @UpdateDateColumn()
+  @UpdateDateColumn({ name: 'updated_at' })
   updatedAt!: Date;
 }

--- a/backend/src/modules/organizations/organization.entity.ts
+++ b/backend/src/modules/organizations/organization.entity.ts
@@ -26,7 +26,7 @@ export class Organization {
   @Column({ default: true })
   isActive!: boolean;
 
-  @Column()
+  @Column({ name: 'game_id' })
   @Index()
   gameId!: number;
 

--- a/backend/src/modules/uex/uex.controller.ts
+++ b/backend/src/modules/uex/uex.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { UexService } from './uex.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('api/uex')
+@UseGuards(JwtAuthGuard)
+export class UexController {
+  constructor(private readonly uexService: UexService) {}
+
+  @Get('categories')
+  async listCategories() {
+    return this.uexService.getActiveCategories();
+  }
+}

--- a/backend/src/modules/uex/uex.module.ts
+++ b/backend/src/modules/uex/uex.module.ts
@@ -12,6 +12,8 @@ import {
   UexOutpost,
   UexPoi,
 } from './entities';
+import { UexService } from './uex.service';
+import { UexController } from './uex.controller';
 
 @Module({
   imports: [
@@ -28,7 +30,8 @@ import {
       UexPoi,
     ]),
   ],
-  providers: [],
-  exports: [],
+  providers: [UexService],
+  controllers: [UexController],
+  exports: [UexService],
 })
 export class UexModule {}

--- a/backend/src/modules/uex/uex.service.ts
+++ b/backend/src/modules/uex/uex.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UexCategory } from './entities/uex-category.entity';
+
+@Injectable()
+export class UexService {
+  constructor(
+    @InjectRepository(UexCategory)
+    private readonly categoryRepository: Repository<UexCategory>,
+  ) {}
+
+  async getActiveCategories(): Promise<
+    Array<{ id: number; name: string; section?: string; type?: string }>
+  > {
+    const categories = await this.categoryRepository.find({
+      where: { active: true, deleted: false },
+      order: { name: 'ASC' },
+      select: ['id', 'name', 'section', 'type'],
+    });
+
+    return categories.map((category) => ({
+      id: Number(category.id),
+      name: category.name,
+      section: category.section || undefined,
+      type: category.type || undefined,
+    }));
+  }
+}

--- a/backend/src/modules/user-inventory/dto/user-inventory-item.dto.ts
+++ b/backend/src/modules/user-inventory/dto/user-inventory-item.dto.ts
@@ -25,6 +25,7 @@ export class UserInventoryItemDto {
   itemName?: string;
   locationName?: string;
   sharedOrgName?: string;
+  categoryName?: string;
 }
 
 export class CreateUserInventoryItemDto {
@@ -81,6 +82,10 @@ export class UserInventorySearchDto {
 
   @IsOptional()
   @IsInt()
+  categoryId?: number;
+
+  @IsOptional()
+  @IsInt()
   uexItemId?: number;
 
   @IsOptional()
@@ -98,8 +103,25 @@ export class UserInventorySearchDto {
   @IsOptional()
   @IsInt()
   @Min(1)
-  @Max(500)
+  @Max(200)
   limit?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  offset?: number;
+
+  @IsOptional()
+  @IsString()
+  sort?: 'name' | 'quantity' | 'date_added' | 'date_modified';
+
+  @IsOptional()
+  @IsString()
+  order?: 'asc' | 'desc';
+
+  @IsOptional()
+  @IsBoolean()
+  sharedOnly?: boolean;
 }
 
 export class UserInventorySummaryDto {

--- a/backend/src/modules/user-inventory/user-inventory.service.spec.ts
+++ b/backend/src/modules/user-inventory/user-inventory.service.spec.ts
@@ -45,7 +45,8 @@ describe('UserInventoryService', () => {
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
-    getMany: jest.fn(),
+    skip: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
     getRawOne: jest.fn(),
@@ -81,13 +82,17 @@ describe('UserInventoryService', () => {
   describe('findAll', () => {
     it('should return all inventory items for a user', async () => {
       const searchDto: UserInventorySearchDto = { gameId: 1 };
-      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockInventoryItem],
+        1,
+      ]);
 
       const result = await service.findAll(1, searchDto);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe(mockInventoryItem.id);
-      expect(result[0].itemName).toBe('Test Item');
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.items[0].id).toBe(mockInventoryItem.id);
+      expect(result.items[0].itemName).toBe('Test Item');
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
         'inventory.user_id = :userId',
         { userId: 1 },
@@ -96,7 +101,10 @@ describe('UserInventoryService', () => {
 
     it('should filter by uexItemId', async () => {
       const searchDto: UserInventorySearchDto = { gameId: 1, uexItemId: 100 };
-      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockInventoryItem],
+        1,
+      ]);
 
       await service.findAll(1, searchDto);
 
@@ -111,7 +119,10 @@ describe('UserInventoryService', () => {
         gameId: 1,
         locationId: 200,
       };
-      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockInventoryItem],
+        1,
+      ]);
 
       await service.findAll(1, searchDto);
 
@@ -126,7 +137,10 @@ describe('UserInventoryService', () => {
         gameId: 1,
         search: 'test',
       };
-      mockQueryBuilder.getMany.mockResolvedValue([mockInventoryItem]);
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockInventoryItem],
+        1,
+      ]);
 
       await service.findAll(1, searchDto);
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,18 +1,24 @@
 {
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "strict": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts", "src/data-source.ts"],
+  "exclude": ["node_modules", "dist", "test"],
+  "ts-node": {
+    "transpileOnly": true,
+    "files": true,
     "compilerOptions": {
-      "module": "commonjs",
-      "target": "es6",
-      "strict": true,
-      "esModuleInterop": true,
-      "emitDecoratorMetadata": true,
-      "experimentalDecorators": true,      
-      "skipLibCheck": true,
-      "outDir": "./dist",
-      "rootDir": "./src",
-      "resolveJsonModule": true,
-      "types": ["node", "jest"]
-    },
-    "include": ["src/**/*.ts", "src/data-source.ts"],
-    "exclude": ["node_modules", "dist", "test"]
+      "module": "commonjs"
+    }
   }
-  
+}

--- a/frontend/src/components/inventory/InventoryPortlet.tsx
+++ b/frontend/src/components/inventory/InventoryPortlet.tsx
@@ -1,0 +1,292 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  IconButton,
+  TextField,
+  FormControlLabel,
+  Switch,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  CircularProgress,
+  Typography,
+  Chip,
+} from '@mui/material';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import InventoryIcon from '@mui/icons-material/Inventory';
+import {
+  inventoryService,
+  InventoryItem,
+  InventoryCategory,
+  InventorySearchParams,
+} from '../../services/inventory.service';
+
+interface InventoryPortletProps {
+  gameId?: number;
+  onExpand?: () => void;
+}
+
+// Debounce hook
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+const InventoryPortlet = ({ gameId = 1, onExpand }: InventoryPortletProps) => {
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [sharedOnly, setSharedOnly] = useState(false);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [totalCount, setTotalCount] = useState(0);
+  const [categories, setCategories] = useState<InventoryCategory[]>([]);
+  const [categoryId, setCategoryId] = useState<number | ''>('');
+
+  const debouncedSearch = useDebounce(search, 300);
+
+  useEffect(() => {
+    const loadCategories = async () => {
+      try {
+        const data = await inventoryService.getCategories();
+        setCategories(data);
+      } catch (error) {
+        console.error('Error loading categories', error);
+      }
+    };
+
+    loadCategories();
+  }, []);
+
+  const fetchInventory = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params: InventorySearchParams = {
+        gameId,
+        limit: rowsPerPage,
+        offset: page * rowsPerPage,
+        search: debouncedSearch || undefined,
+        sharedOnly,
+        categoryId: typeof categoryId === 'number' ? categoryId : undefined,
+      };
+
+      const { items: fetchedItems, total } = await inventoryService.getInventory(
+        params,
+      );
+
+      setItems(fetchedItems);
+      setTotalCount(total ?? fetchedItems.length);
+    } catch (error) {
+      console.error('Error fetching inventory:', error);
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [gameId, debouncedSearch, sharedOnly, page, rowsPerPage, categoryId]);
+
+  useEffect(() => {
+    fetchInventory();
+  }, [fetchInventory]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch, sharedOnly, categoryId]);
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Card
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <CardHeader
+        avatar={
+          <Box
+            sx={{
+              display: 'inline-flex',
+              p: 1.5,
+              borderRadius: '8px',
+              background: 'rgba(74, 158, 255, 0.1)',
+            }}
+          >
+            <InventoryIcon sx={{ fontSize: 24, color: '#4A9EFF' }} />
+          </Box>
+        }
+        title={
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            My Inventory
+          </Typography>
+        }
+        action={
+          onExpand && (
+            <IconButton onClick={onExpand} size="small">
+              <OpenInFullIcon />
+            </IconButton>
+          )
+        }
+      />
+      <CardContent sx={{ flexGrow: 1, pt: 0 }}>
+        {/* Search and Filters */}
+        <Box sx={{ mb: 2, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <TextField
+            size="small"
+            placeholder="Search items..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            sx={{ flexGrow: 1, minWidth: 200 }}
+          />
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <InputLabel id="inventory-category-label">Category</InputLabel>
+            <Select
+              labelId="inventory-category-label"
+              label="Category"
+              value={categoryId}
+              onChange={(e) =>
+                setCategoryId(
+                  e.target.value === '' ? '' : Number(e.target.value),
+                )
+              }
+            >
+              <MenuItem value="">
+                <em>All categories</em>
+              </MenuItem>
+              {categories.map((category) => (
+                <MenuItem key={category.id} value={category.id}>
+                  {category.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={sharedOnly}
+                onChange={(e) => setSharedOnly(e.target.checked)}
+                size="small"
+              />
+            }
+            label="Shared only"
+          />
+        </Box>
+
+        {/* Items Table */}
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : items.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 4 }}>
+            <Typography variant="body2" color="text.secondary">
+              {search
+                ? 'No items found matching your search'
+                : 'No inventory items yet'}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <TableContainer sx={{ maxHeight: 400 }}>
+              <Table stickyHeader size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Item</TableCell>
+                    <TableCell>Category</TableCell>
+                    <TableCell align="right">Quantity</TableCell>
+                    <TableCell>Location</TableCell>
+                    <TableCell>Status</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {items.map((item) => (
+                    <TableRow
+                      key={item.id}
+                      hover
+                      sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                    >
+                      <TableCell>
+                        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                          {item.itemName || `Item #${item.uexItemId}`}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" color="text.secondary">
+                          {item.categoryName || '—'}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography variant="body2">
+                          {item.quantity.toLocaleString()}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" color="text.secondary">
+                          {item.locationName || `Location #${item.locationId}`}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        {item.sharedOrgId ? (
+                          <Chip
+                            label={item.sharedOrgName || 'Shared'}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                          />
+                        ) : (
+                          <Chip label="Private" size="small" variant="outlined" />
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+
+            {/* Pagination */}
+            <TablePagination
+              rowsPerPageOptions={[5, 10, 25]}
+              component="div"
+              count={totalCount}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onPageChange={handleChangePage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default InventoryPortlet;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import {
 import GroupsIcon from '@mui/icons-material/Groups';
 import PersonIcon from '@mui/icons-material/Person';
 import LogoutIcon from '@mui/icons-material/Logout';
+import InventoryPortlet from '../components/inventory/InventoryPortlet';
 
 interface User {
   username: string;
@@ -247,6 +248,14 @@ const Dashboard = () => {
                 </Typography>
               </CardContent>
             </Card>
+          </Grid>
+
+          {/* Inventory Portlet - Full Width */}
+          <Grid item xs={12}>
+            <InventoryPortlet
+              gameId={1}
+              onExpand={() => navigate('/inventory')}
+            />
           </Grid>
         </Grid>
 

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -1,0 +1,113 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  AppBar,
+  Toolbar,
+  IconButton,
+  Typography,
+  Avatar,
+  Container,
+  Box,
+  CircularProgress,
+} from '@mui/material';
+import LogoutIcon from '@mui/icons-material/Logout';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import InventoryPortlet from '../components/inventory/InventoryPortlet';
+import { useEffect, useState } from 'react';
+
+const InventoryPage = () => {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      try {
+        const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+        const token = localStorage.getItem('access_token');
+        const response = await fetch(`${apiUrl}/users/profile`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          setUsername(data.username);
+        } else {
+          navigate('/login');
+        }
+      } catch (error) {
+        console.error('Error fetching profile:', error);
+        navigate('/login');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserProfile();
+  }, [navigate]);
+
+  const handleLogout = () => {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('refresh_token');
+    navigate('/login');
+  };
+
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '100vh',
+          backgroundColor: '#1e2328',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ minHeight: '100vh', backgroundColor: '#1e2328' }}>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton color="inherit" onClick={() => navigate('/dashboard')}>
+            <ArrowBackIcon />
+          </IconButton>
+          <Typography
+            variant="h6"
+            sx={{
+              flexGrow: 1,
+              fontWeight: 700,
+              ml: 1,
+              background: 'linear-gradient(135deg, #4A9EFF 0%, #7ABDFF 100%)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              cursor: 'pointer',
+            }}
+            onClick={() => navigate('/dashboard')}
+          >
+            Inventory
+          </Typography>
+          <IconButton color="inherit" onClick={handleLogout}>
+            <LogoutIcon />
+          </IconButton>
+          <Avatar sx={{ width: 32, height: 32, ml: 1, bgcolor: '#4A9EFF' }}>
+            {username?.charAt(0).toUpperCase() || 'U'}
+          </Avatar>
+        </Toolbar>
+      </AppBar>
+
+      <Container maxWidth="lg" sx={{ py: 6 }}>
+        <Typography variant="h4" sx={{ mb: 3, fontWeight: 700, color: '#e8eaed' }}>
+          My Inventory
+        </Typography>
+        <InventoryPortlet gameId={1} />
+      </Container>
+    </Box>
+  );
+};
+
+export default InventoryPage;

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -7,6 +7,7 @@ import Register from './pages/Register';
 import ResetPassword from './pages/ResetPassword';
 import Dashboard from './pages/Dashboard';
 import Profile from './pages/Profile';
+import Inventory from './pages/Inventory';
 import ProtectedRoute from './components/ProtectedRoute';
 
 const AppRoutes = () => (
@@ -21,6 +22,7 @@ const AppRoutes = () => (
       <Route element={<ProtectedRoute />}>
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/profile" element={<Profile />} />
+        <Route path="/inventory" element={<Inventory />} />
       </Route>
     </Routes>
   </Router>

--- a/frontend/src/services/inventory.service.ts
+++ b/frontend/src/services/inventory.service.ts
@@ -1,0 +1,152 @@
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+
+export interface InventoryItem {
+  id: string;
+  userId: number;
+  gameId: number;
+  uexItemId: number;
+  locationId: number;
+  quantity: number;
+  notes?: string;
+  sharedOrgId?: number | null;
+  active: boolean;
+  dateAdded: Date;
+  dateModified: Date;
+  itemName?: string;
+  locationName?: string;
+  sharedOrgName?: string;
+  categoryName?: string;
+}
+
+export interface InventorySearchParams {
+  gameId: number;
+  categoryId?: number;
+  uexItemId?: number;
+  locationId?: number;
+  sharedOnly?: boolean;
+  sharedOrgId?: number;
+  search?: string;
+  limit?: number;
+  offset?: number;
+  sort?: 'name' | 'quantity' | 'date_added' | 'date_modified';
+  order?: 'asc' | 'desc';
+}
+
+export interface InventorySummary {
+  userId: number;
+  gameId: number;
+  totalItems: number;
+  uniqueItems: number;
+  locationCount: number;
+  sharedItemsCount: number;
+  lastUpdated: Date;
+}
+
+export interface InventoryListResponse {
+  items: InventoryItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface InventoryCategory {
+  id: number;
+  name: string;
+  section?: string;
+  type?: string;
+}
+
+const buildInventoryQuery = (params: InventorySearchParams) => {
+  const query: Record<string, string | number | boolean> = {
+    game_id: params.gameId,
+  };
+
+  if (params.categoryId !== undefined) query.category_id = params.categoryId;
+  if (params.uexItemId !== undefined) query.uex_item_id = params.uexItemId;
+  if (params.locationId !== undefined) query.location_id = params.locationId;
+  if (params.sharedOnly !== undefined) query.shared_only = params.sharedOnly;
+  if (params.sharedOrgId !== undefined) query.shared_org_id = params.sharedOrgId;
+  if (params.search) query.search = params.search;
+  if (params.limit !== undefined) query.limit = params.limit;
+  if (params.offset !== undefined) query.offset = params.offset;
+  if (params.sort) query.sort = params.sort;
+  if (params.order) query.order = params.order;
+
+  return query;
+};
+
+const getAuthHeader = () => {
+  const token = localStorage.getItem('access_token');
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+};
+
+export const inventoryService = {
+  /**
+   * Get user inventory with filters
+   */
+  async getInventory(
+    params: InventorySearchParams,
+  ): Promise<InventoryListResponse> {
+    const response = await axios.get(`${API_URL}/api/inventory`, {
+      params: buildInventoryQuery(params),
+      headers: getAuthHeader(),
+    });
+    return response.data;
+  },
+
+  /**
+   * Get active UEX categories for filtering
+   */
+  async getCategories(): Promise<InventoryCategory[]> {
+    const response = await axios.get(`${API_URL}/api/uex/categories`, {
+      headers: getAuthHeader(),
+    });
+    return response.data;
+  },
+
+  /**
+   * Get inventory summary statistics
+   */
+  async getSummary(gameId: number): Promise<InventorySummary> {
+    const response = await axios.get(
+      `${API_URL}/api/inventory/summary/${gameId}`,
+      {
+        headers: getAuthHeader(),
+      },
+    );
+    return response.data;
+  },
+
+  /**
+   * Create new inventory item
+   */
+  async createItem(item: Omit<InventoryItem, 'id' | 'userId' | 'dateAdded' | 'dateModified' | 'active'>): Promise<InventoryItem> {
+    const response = await axios.post(`${API_URL}/api/inventory`, item, {
+      headers: getAuthHeader(),
+    });
+    return response.data;
+  },
+
+  /**
+   * Update inventory item
+   */
+  async updateItem(id: string, updates: Partial<InventoryItem>): Promise<InventoryItem> {
+    const response = await axios.put(`${API_URL}/api/inventory/${id}`, updates, {
+      headers: getAuthHeader(),
+    });
+    return response.data;
+  },
+
+  /**
+   * Delete inventory item
+   */
+  async deleteItem(id: string): Promise<void> {
+    await axios.delete(`${API_URL}/api/inventory/${id}`, {
+      headers: getAuthHeader(),
+    });
+  },
+};


### PR DESCRIPTION
Implements paginated inventory list with search/filtering:

- Server: GET /api/inventory now supports game/category/shared filters, sort/order, limit/offset; returns items+total

- Server: category names included; UEX categories endpoint added for dropdown

- Client: portlet uses server pagination, debounced search, category dropdown, shared-only toggle, category column

UI flow:

- Expand button opens full /inventory page

- Inventory service uses snake_case params and fetches categories

Tests: pnpm test (all packages)