### PR TITLE
fix: correct inventory sort mappings

### DIFF
--- a/backend/src/modules/user-inventory/user-inventory.service.ts
+++ b/backend/src/modules/user-inventory/user-inventory.service.ts
@@ -250,10 +250,10 @@ export class UserInventoryService {
       case 'quantity':
         return 'inventory.quantity';
       case 'date_added':
-        return 'inventory.date_added';
+        return 'inventory.dateAdded';
       case 'date_modified':
       default:
-        return 'inventory.date_modified';
+        return 'inventory.dateModified';
     }
   }
 }


### PR DESCRIPTION
Ensure orderBy uses entity property paths so TypeORM resolves columns

- map dateAdded/dateModified to inventory.dateAdded/dateModified

- map quantity to inventory.quantity and name to item.name