### PR TITLE
feat: add inventory pagination and filtering

### DIFF
--- a/backend/src/modules/org-inventory/dto/org-inventory-item.dto.ts
+++ b/backend/src/modules/org-inventory/dto/org-inventory-item.dto.ts
@@ -30,6 +30,7 @@ export class OrgInventoryItemDto {
   orgName?: string;
   addedByUsername?: string;
   modifiedByUsername?: string;
+  categoryName?: string;
 }
 
 export class CreateOrgInventoryItemDto {
@@ -108,10 +109,38 @@ export class OrgInventorySearchDto {
   @IsInt()
   gameId!: number;
 
+  @ApiPropertyOptional({
+    description: 'Minimum quantity filter',
+    example: 10,
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  minQuantity?: number;
+
+  @ApiPropertyOptional({
+    description: 'Maximum quantity filter',
+    example: 1000,
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  maxQuantity?: number;
+
   @ApiPropertyOptional({ description: 'Filter by UEX Item ID', example: 100 })
   @IsOptional()
   @IsInt()
   uexItemId?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by UEX category ID',
+    example: 12,
+  })
+  @IsOptional()
+  @IsInt()
+  categoryId?: number;
 
   @ApiPropertyOptional({ description: 'Filter by Location ID', example: 200 })
   @IsOptional()
@@ -134,6 +163,24 @@ export class OrgInventorySearchDto {
   @IsOptional()
   @IsBoolean()
   activeOnly?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Sort column',
+    example: 'date_modified',
+    enum: ['name', 'quantity', 'location', 'date_added', 'date_modified'],
+  })
+  @IsOptional()
+  @IsString()
+  sort?: 'name' | 'quantity' | 'location' | 'date_added' | 'date_modified';
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    example: 'desc',
+    enum: ['asc', 'desc'],
+  })
+  @IsOptional()
+  @IsString()
+  order?: 'asc' | 'desc';
 
   @ApiPropertyOptional({
     description: 'Maximum number of results',

--- a/backend/src/modules/org-inventory/org-inventory.controller.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.ts
@@ -53,7 +53,12 @@ export class OrgInventoryController {
     @Request() req: any,
     @Param('orgId', ParseIntPipe) orgId: number,
     @Query() searchDto: OrgInventorySearchDto,
-  ): Promise<OrgInventoryItemDto[]> {
+  ): Promise<{
+    items: OrgInventoryItemDto[];
+    total: number;
+    limit: number;
+    offset: number;
+  }> {
     const userId = req.user.userId;
     // Extract gameId from query params and use search
     return this.orgInventoryService.search(userId, {

--- a/backend/src/modules/org-inventory/org-inventory.service.spec.ts
+++ b/backend/src/modules/org-inventory/org-inventory.service.spec.ts
@@ -276,19 +276,26 @@ describe('OrgInventoryService', () => {
       jest.spyOn(permissionsService, 'hasPermission').mockResolvedValue(true);
       jest
         .spyOn(repository, 'searchInventory')
-        .mockResolvedValue([mockOrgInventoryItem]);
+        .mockResolvedValue({ items: [mockOrgInventoryItem], total: 1 });
 
       const result = await service.search(1, searchDto);
 
-      expect(result).toHaveLength(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
       expect(repository.searchInventory).toHaveBeenCalledWith({
         orgId: 1,
         gameId: 1,
         activeOnly: true,
-        limit: 100,
-        offset: 0,
         locationId: undefined,
         uexItemId: undefined,
+        categoryId: undefined,
+        limit: 100,
+        offset: 0,
+        search: undefined,
+        minQuantity: undefined,
+        maxQuantity: undefined,
+        sort: 'date_modified',
+        order: 'desc',
       });
     });
 

--- a/backend/src/modules/user-inventory/dto/user-inventory-item.dto.ts
+++ b/backend/src/modules/user-inventory/dto/user-inventory-item.dto.ts
@@ -81,6 +81,16 @@ export class UserInventorySearchDto {
   gameId!: number;
 
   @IsOptional()
+  @IsNumber()
+  @Min(0)
+  maxQuantity?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  minQuantity?: number;
+
+  @IsOptional()
   @IsInt()
   categoryId?: number;
 
@@ -113,7 +123,7 @@ export class UserInventorySearchDto {
 
   @IsOptional()
   @IsString()
-  sort?: 'name' | 'quantity' | 'date_added' | 'date_modified';
+  sort?: 'name' | 'quantity' | 'location' | 'date_added' | 'date_modified';
 
   @IsOptional()
   @IsString()

--- a/backend/src/modules/user-inventory/user-inventory.controller.ts
+++ b/backend/src/modules/user-inventory/user-inventory.controller.ts
@@ -32,6 +32,13 @@ export class UserInventoryController {
   @Get()
   async list(@Query() query: Record<string, any>, @Request() req: any) {
     const userId = req.user.userId;
+    const parsedMinQuantity = Number(
+      query.min_quantity ?? query.minQuantity ?? Number.NaN,
+    );
+    const parsedMaxQuantity = Number(
+      query.max_quantity ?? query.maxQuantity ?? Number.NaN,
+    );
+
     const searchDto: UserInventorySearchDto = {
       gameId: Number(query.game_id ?? query.gameId),
       categoryId: query.category_id ? Number(query.category_id) : undefined,
@@ -49,6 +56,12 @@ export class UserInventoryController {
         query.shared_only !== undefined
           ? query.shared_only === 'true' || query.shared_only === true
           : undefined,
+      minQuantity: Number.isNaN(parsedMinQuantity)
+        ? undefined
+        : parsedMinQuantity,
+      maxQuantity: Number.isNaN(parsedMaxQuantity)
+        ? undefined
+        : parsedMaxQuantity,
     };
 
     if (!searchDto.gameId) {

--- a/backend/src/modules/user-inventory/user-inventory.service.spec.ts
+++ b/backend/src/modules/user-inventory/user-inventory.service.spec.ts
@@ -149,6 +149,48 @@ describe('UserInventoryService', () => {
         { search: '%test%' },
       );
     });
+
+    it('should filter by min and max quantity', async () => {
+      const searchDto: UserInventorySearchDto = {
+        gameId: 1,
+        minQuantity: 5,
+        maxQuantity: 20,
+      };
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockInventoryItem],
+        1,
+      ]);
+
+      await service.findAll(1, searchDto);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'inventory.quantity >= :minQuantity',
+        { minQuantity: 5 },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'inventory.quantity <= :maxQuantity',
+        { maxQuantity: 20 },
+      );
+    });
+
+    it('should sort by location when requested', async () => {
+      const searchDto: UserInventorySearchDto = {
+        gameId: 1,
+        sort: 'location',
+        order: 'asc',
+      };
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([
+        [mockInventoryItem],
+        1,
+      ]);
+
+      await service.findAll(1, searchDto);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'location.displayName',
+        'ASC',
+      );
+    });
   });
 
   describe('findById', () => {

--- a/backend/src/modules/user-inventory/user-inventory.service.ts
+++ b/backend/src/modules/user-inventory/user-inventory.service.ts
@@ -67,6 +67,18 @@ export class UserInventoryService {
       queryBuilder.andWhere('inventory.shared_org_id IS NOT NULL');
     }
 
+    if (searchDto.minQuantity !== undefined) {
+      queryBuilder.andWhere('inventory.quantity >= :minQuantity', {
+        minQuantity: searchDto.minQuantity,
+      });
+    }
+
+    if (searchDto.maxQuantity !== undefined) {
+      queryBuilder.andWhere('inventory.quantity <= :maxQuantity', {
+        maxQuantity: searchDto.maxQuantity,
+      });
+    }
+
     if (searchDto.search) {
       queryBuilder.andWhere(
         '(item.name ILIKE :search OR inventory.notes ILIKE :search)',
@@ -249,6 +261,8 @@ export class UserInventoryService {
         return 'item.name';
       case 'quantity':
         return 'inventory.quantity';
+      case 'location':
+        return 'location.displayName';
       case 'date_added':
         return 'inventory.dateAdded';
       case 'date_modified':

--- a/frontend/src/services/inventory.service.ts
+++ b/frontend/src/services/inventory.service.ts
@@ -52,9 +52,11 @@ export interface InventorySearchParams {
   sharedOnly?: boolean;
   sharedOrgId?: number;
   search?: string;
+  minQuantity?: number;
+  maxQuantity?: number;
   limit?: number;
   offset?: number;
-  sort?: 'name' | 'quantity' | 'date_added' | 'date_modified';
+  sort?: 'name' | 'quantity' | 'location' | 'date_added' | 'date_modified';
   order?: 'asc' | 'desc';
 }
 
@@ -93,6 +95,8 @@ const buildInventoryQuery = (params: InventorySearchParams) => {
   if (params.sharedOnly !== undefined) query.shared_only = params.sharedOnly;
   if (params.sharedOrgId !== undefined) query.shared_org_id = params.sharedOrgId;
   if (params.search) query.search = params.search;
+  if (params.minQuantity !== undefined) query.min_quantity = params.minQuantity;
+  if (params.maxQuantity !== undefined) query.max_quantity = params.maxQuantity;
   if (params.limit !== undefined) query.limit = params.limit;
   if (params.offset !== undefined) query.offset = params.offset;
   if (params.sort) query.sort = params.sort;
@@ -111,9 +115,14 @@ const getAuthHeader = () => {
 const buildOrgInventoryQuery = (params: {
   gameId: number;
   uexItemId?: number;
+  categoryId?: number;
   locationId?: number;
   activeOnly?: boolean;
   search?: string;
+  minQuantity?: number;
+  maxQuantity?: number;
+  sort?: 'name' | 'quantity' | 'location' | 'date_added' | 'date_modified';
+  order?: 'asc' | 'desc';
   limit?: number;
   offset?: number;
 }) => {
@@ -122,9 +131,14 @@ const buildOrgInventoryQuery = (params: {
   };
 
   if (params.uexItemId !== undefined) query.uexItemId = params.uexItemId;
+  if (params.categoryId !== undefined) query.categoryId = params.categoryId;
   if (params.locationId !== undefined) query.locationId = params.locationId;
   if (params.activeOnly !== undefined) query.activeOnly = params.activeOnly;
   if (params.search) query.search = params.search;
+  if (params.minQuantity !== undefined) query.minQuantity = params.minQuantity;
+  if (params.maxQuantity !== undefined) query.maxQuantity = params.maxQuantity;
+  if (params.sort) query.sort = params.sort;
+  if (params.order) query.order = params.order;
   if (params.limit !== undefined) query.limit = params.limit;
   if (params.offset !== undefined) query.offset = params.offset;
 
@@ -242,9 +256,14 @@ export const inventoryService = {
     params: {
       gameId: number;
       uexItemId?: number;
+      categoryId?: number;
       locationId?: number;
       activeOnly?: boolean;
       search?: string;
+      minQuantity?: number;
+      maxQuantity?: number;
+      sort?: 'name' | 'quantity' | 'location' | 'date_added' | 'date_modified';
+      order?: 'asc' | 'desc';
       limit?: number;
       offset?: number;
     },
@@ -257,13 +276,7 @@ export const inventoryService = {
       },
     );
 
-    const items: OrgInventoryItem[] = response.data;
-    return {
-      items,
-      total: items.length,
-      limit: params.limit ?? items.length,
-      offset: params.offset ?? 0,
-    };
+    return response.data;
   },
 
   /**


### PR DESCRIPTION
- add min/max quantity and category filtering across user/org inventory APIs with pagination and sorting

- wire full-screen inventory view to paginated backend responses and totals

- cover new filters/sorting in inventory service tests; lint passes