### PR TITLE
Refactor: extract reusable inventory components

### DIFF
--- a/frontend/src/components/inventory/InventoryFiltersPanel.tsx
+++ b/frontend/src/components/inventory/InventoryFiltersPanel.tsx
@@ -1,0 +1,318 @@
+import {
+  Avatar,
+  Box,
+  Button,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
+  Slider,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import GroupWorkIcon from '@mui/icons-material/GroupWork';
+import SortIcon from '@mui/icons-material/Sort';
+import ViewAgendaIcon from '@mui/icons-material/ViewAgenda';
+import ApartmentIcon from '@mui/icons-material/Apartment';
+import type { InventoryCategory } from '../../services/inventory.service';
+
+interface FiltersPanelProps {
+  filters: {
+    search: string;
+    categoryId: number | '';
+    locationId: number | '';
+    sharedOnly: boolean;
+    valueRange: [number, number];
+  };
+  setFilters: (
+    updater:
+      | FiltersPanelProps['filters']
+      | ((prev: FiltersPanelProps['filters']) => FiltersPanelProps['filters']),
+  ) => void;
+  categories: InventoryCategory[];
+  locationOptions: { id: number; name: string }[];
+  valueText: (value: number) => string;
+  maxQuantity: number;
+  sortBy: 'name' | 'quantity' | 'location' | 'date';
+  sortDir: 'asc' | 'desc';
+  setSortBy: (value: 'name' | 'quantity' | 'location' | 'date') => void;
+  setSortDir: (updater: (prev: 'asc' | 'desc') => 'asc' | 'desc') => void;
+  groupBy: 'none' | 'category' | 'location' | 'share';
+  setGroupBy: (value: 'none' | 'category' | 'location' | 'share') => void;
+  density: 'standard' | 'compact';
+  setDensity: (value: 'standard' | 'compact') => void;
+  viewMode: 'personal' | 'org';
+  setViewMode: (mode: 'personal' | 'org') => void;
+  selectedOrgId: number | null;
+  setSelectedOrgId: (value: number | null) => void;
+  orgOptions: { id: number; name: string }[];
+  userInitial: string;
+  onOpenAddDialog: () => void;
+  showAddButton: boolean;
+  totalCount: number;
+  itemCount: number;
+}
+
+export const InventoryFiltersPanel = ({
+  filters,
+  setFilters,
+  categories,
+  locationOptions,
+  valueText,
+  maxQuantity,
+  sortBy,
+  sortDir,
+  setSortBy,
+  setSortDir,
+  groupBy,
+  setGroupBy,
+  density,
+  setDensity,
+  viewMode,
+  setViewMode,
+  selectedOrgId,
+  setSelectedOrgId,
+  orgOptions,
+  userInitial,
+  onOpenAddDialog,
+  showAddButton,
+  totalCount,
+  itemCount,
+}: FiltersPanelProps) => {
+  return (
+    <>
+      <Grid container spacing={2} alignItems="center">
+        <Grid item xs={12} md={4} lg={3}>
+          <TextField
+            fullWidth
+            label="Search by name, note, or location"
+            placeholder="Prospector, Lorville, armors..."
+            value={filters.search}
+            onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value }))}
+          />
+        </Grid>
+        <Grid item xs={6} md={2}>
+          <FormControl fullWidth>
+            <InputLabel id="category-filter-label">Category</InputLabel>
+            <Select
+              labelId="category-filter-label"
+              label="Category"
+              value={filters.categoryId}
+              onChange={(e) =>
+                setFilters((prev) => ({
+                  ...prev,
+                  categoryId: e.target.value === '' ? '' : Number(e.target.value),
+                }))
+              }
+            >
+              <MenuItem value="">
+                <em>All</em>
+              </MenuItem>
+              {categories.map((category) => (
+                <MenuItem key={category.id} value={category.id}>
+                  {category.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={6} md={2}>
+          <FormControl fullWidth>
+            <InputLabel id="location-filter-label">Location</InputLabel>
+            <Select
+              labelId="location-filter-label"
+              label="Location"
+              value={filters.locationId}
+              onChange={(e) =>
+                setFilters((prev) => ({
+                  ...prev,
+                  locationId: e.target.value === '' ? '' : Number(e.target.value),
+                }))
+              }
+            >
+              <MenuItem value="">
+                <em>All</em>
+              </MenuItem>
+              {locationOptions.map((loc) => (
+                <MenuItem key={loc.id} value={loc.id}>
+                  {loc.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} md={4} lg={3}>
+          <Box sx={{ px: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              Value (quantity) range
+            </Typography>
+            <Slider
+              value={filters.valueRange}
+              min={0}
+              max={Math.max(filters.valueRange[1], maxQuantity || 1000)}
+              onChange={(_, value) =>
+                setFilters((prev) => ({
+                  ...prev,
+                  valueRange: value as [number, number],
+                }))
+              }
+              valueLabelDisplay="auto"
+              getAriaValueText={valueText}
+            />
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={2} lg={2}>
+          <FormControl fullWidth>
+            <InputLabel id="org-selector-label">View</InputLabel>
+            <Select
+              labelId="org-selector-label"
+              label="View"
+              value={viewMode === 'personal' ? 'personal' : selectedOrgId ?? ''}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === 'personal') {
+                  setViewMode('personal');
+                  setSelectedOrgId(null);
+                } else {
+                  setViewMode('org');
+                  setSelectedOrgId(Number(value));
+                }
+              }}
+            >
+              <MenuItem value="personal">
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Avatar sx={{ width: 24, height: 24 }}>{userInitial}</Avatar>
+                  <ListItemText primary="My Inventory" />
+                </Stack>
+              </MenuItem>
+              {orgOptions.map((org) => (
+                <MenuItem key={org.id} value={org.id}>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <ApartmentIcon fontSize="small" />
+                    <ListItemText primary={org.name} />
+                  </Stack>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      </Grid>
+
+      <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 3, mb: 1, color: '#9aa0a6' }}>
+        <ViewAgendaIcon fontSize="small" />
+        Showing {itemCount.toLocaleString()} of {totalCount.toLocaleString()} items
+      </Typography>
+
+      <Grid container spacing={2} alignItems="center">
+        <Grid item>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={filters.sharedOnly}
+                onChange={(e) =>
+                  setFilters((prev) => ({
+                    ...prev,
+                    sharedOnly: e.target.checked,
+                  }))
+                }
+                size="small"
+                disabled={viewMode === 'org'}
+              />
+            }
+            label="Shared only"
+          />
+        </Grid>
+        <Grid item>
+          <Button
+            startIcon={<SortIcon />}
+            variant="outlined"
+            color="inherit"
+            onClick={() => setSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))}
+          >
+            Sort: {sortBy} ({sortDir})
+          </Button>
+        </Grid>
+        <Grid item>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="sort-by-label">Sort By</InputLabel>
+            <Select
+              labelId="sort-by-label"
+              label="Sort By"
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as 'name' | 'quantity' | 'location' | 'date')}
+            >
+              <MenuItem value="date">Last updated</MenuItem>
+              <MenuItem value="name">Name</MenuItem>
+              <MenuItem value="quantity">Quantity</MenuItem>
+              <MenuItem value="location">Location</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item>
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <InputLabel id="group-by-label">Group By</InputLabel>
+            <Select
+              labelId="group-by-label"
+              label="Group By"
+              value={groupBy}
+              onChange={(e) => setGroupBy(e.target.value as 'none' | 'category' | 'location' | 'share')}
+              startAdornment={<GroupWorkIcon sx={{ mr: 1 }} />}
+            >
+              <MenuItem value="none">No grouping</MenuItem>
+              <MenuItem value="category">Category</MenuItem>
+              <MenuItem value="location">Location</MenuItem>
+              <MenuItem value="share">Share status</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item>
+          <Button
+            variant="outlined"
+            color="inherit"
+            startIcon={<FilterAltIcon />}
+            onClick={() =>
+              setFilters({
+                search: '',
+                categoryId: '',
+                locationId: '',
+                sharedOnly: false,
+                valueRange: [0, maxQuantity || 100000],
+              })
+            }
+          >
+            Clear filters
+          </Button>
+        </Grid>
+        <Grid item>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="density-select-label">View mode</InputLabel>
+            <Select
+              labelId="density-select-label"
+              label="View mode"
+              value={density}
+              onChange={(e) => setDensity(e.target.value as 'standard' | 'compact')}
+            >
+              <MenuItem value="standard">Standard</MenuItem>
+              <MenuItem value="compact">Editor Mode</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+        {showAddButton && (
+          <Grid item>
+            <Button variant="contained" onClick={onOpenAddDialog}>
+              Add item
+            </Button>
+          </Grid>
+        )}
+      </Grid>
+    </>
+  );
+};
+
+export default InventoryFiltersPanel;

--- a/frontend/src/components/inventory/InventoryInlineRow.tsx
+++ b/frontend/src/components/inventory/InventoryInlineRow.tsx
@@ -1,0 +1,351 @@
+import { useMemo } from 'react';
+import type { MouseEvent } from 'react';
+import {
+  Autocomplete,
+  Box,
+  Chip,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import type { InventoryItem, OrgInventoryItem } from '../../services/inventory.service';
+import type { FocusController } from '../../utils/focusController';
+
+export type InventoryRecord = InventoryItem | OrgInventoryItem;
+
+interface LocationOption {
+  id: number;
+  name: string;
+}
+
+interface InventoryInlineRowProps {
+  item: InventoryRecord;
+  density: 'standard' | 'compact';
+  allLocations: LocationOption[];
+  inlineDraft: { locationId: number | ''; quantity: number | '' };
+  inlineLocationInput: string;
+  locationEditing: boolean;
+  inlineSaving: boolean;
+  inlineError?: string | null;
+  isDirty: boolean;
+  focusController: FocusController<string, 'location' | 'quantity' | 'save'>;
+  rowKey: string;
+  onDraftChange: (changes: Partial<{ locationId: number | ''; quantity: number | '' }>) => void;
+  onErrorChange: (message: string | null) => void;
+  onLocationInputChange: (value: string) => void;
+  onLocationFocus: () => void;
+  onLocationBlur: (selectedName?: string) => void;
+  onSave: () => void;
+  onOpenActions?: (event: MouseEvent<HTMLButtonElement>) => void;
+  setLocationRef: (ref: HTMLInputElement | null, key: string) => void;
+  setQuantityRef: (ref: HTMLInputElement | null, key: string) => void;
+  setSaveRef: (ref: HTMLButtonElement | null, key: string) => void;
+}
+
+export const InventoryInlineRow = ({
+  item,
+  density,
+  allLocations,
+  inlineDraft,
+  inlineLocationInput,
+  locationEditing,
+  inlineSaving,
+  inlineError,
+  isDirty,
+  focusController,
+  rowKey,
+  onDraftChange,
+  onErrorChange,
+  onLocationInputChange,
+  onLocationFocus,
+  onLocationBlur,
+  onSave,
+  onOpenActions,
+  setLocationRef,
+  setQuantityRef,
+  setSaveRef,
+}: InventoryInlineRowProps) => {
+  const draftLocationId =
+    typeof inlineDraft.locationId === 'string'
+      ? Number(inlineDraft.locationId)
+      : inlineDraft.locationId;
+  const selectedLocation =
+    allLocations.find((loc) => loc.id === draftLocationId) ||
+    (typeof draftLocationId === 'number'
+      ? {
+          id: draftLocationId,
+          name: item.locationName || `Location #${draftLocationId}`,
+        }
+      : null);
+
+  const filteredOptions = useMemo(() => {
+    const filterTerm = inlineLocationInput.trim().toLowerCase();
+    return allLocations
+      .filter((opt) => opt.name.toLowerCase().includes(filterTerm))
+      .sort((a, b) => {
+        const aName = a.name.toLowerCase();
+        const bName = b.name.toLowerCase();
+        const aStarts = aName.startsWith(filterTerm);
+        const bStarts = bName.startsWith(filterTerm);
+        if (aStarts !== bStarts) return aStarts ? -1 : 1;
+        const aIndex = aName.indexOf(filterTerm);
+        const bIndex = bName.indexOf(filterTerm);
+        if (aIndex !== bIndex) return aIndex - bIndex;
+        return a.name.localeCompare(b.name);
+      });
+  }, [allLocations, inlineLocationInput]);
+
+  const draftQuantityNumber = Number(inlineDraft.quantity);
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: '1fr',
+          md: density === 'compact' ? '2fr 1fr 1fr 1fr auto' : '2fr 1fr 1fr 1fr auto',
+        },
+        gap: density === 'compact' ? 0.75 : 2,
+        alignItems: 'center',
+        px: density === 'compact' ? 1 : 2,
+        py: density === 'compact' ? 0.45 : 1.5,
+        '&:hover': {
+          backgroundColor: 'rgba(255,255,255,0.02)',
+        },
+      }}
+    >
+      <Stack spacing={density === 'compact' ? 0.25 : 0.5}>
+        <Stack
+          direction="row"
+          spacing={density === 'compact' ? 0.5 : 1}
+          alignItems="center"
+          flexWrap="wrap"
+          columnGap={density === 'compact' ? 0.75 : 1}
+          rowGap={density === 'compact' ? 0.25 : 0.5}
+        >
+          <Typography
+            variant={density === 'compact' ? 'body2' : 'subtitle1'}
+            sx={{ fontWeight: 600 }}
+            noWrap
+            title={item.itemName || `Item #${item.uexItemId}`}
+          >
+            {item.itemName || `Item #${item.uexItemId}`}
+          </Typography>
+          <Chip
+            label={item.categoryName || 'General'}
+            size={density === 'compact' ? 'small' : 'medium'}
+            variant="outlined"
+          />
+          {item.sharedOrgId && (
+            <Chip
+              size={density === 'compact' ? 'small' : 'medium'}
+              color="primary"
+              variant="outlined"
+              label={item.sharedOrgName || 'Shared'}
+            />
+          )}
+        </Stack>
+      </Stack>
+      <Stack spacing={density === 'compact' ? 0.25 : 0.5}>
+        {density !== 'compact' ? (
+          <>
+            <Typography variant="body2" color="text.secondary">
+              Location
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {item.locationName || 'Unknown'}
+            </Typography>
+          </>
+        ) : (
+          <Autocomplete
+            size="small"
+            fullWidth
+            options={filteredOptions}
+            autoHighlight
+            openOnFocus
+            filterOptions={(options) => options}
+            value={locationEditing ? null : selectedLocation}
+            inputValue={inlineLocationInput}
+            getOptionLabel={(option) => option?.name ?? ''}
+            isOptionEqualToValue={(option, value) => option.id === value.id}
+            onChange={(_, value) => {
+              onDraftChange({ locationId: value ? value.id : '' });
+              onLocationInputChange(value?.name ?? '');
+              onLocationBlur(value?.name ?? '');
+              onErrorChange(null);
+            }}
+            onInputChange={(_, value) => {
+              onLocationInputChange(value);
+            }}
+            onFocus={() => {
+              onLocationFocus();
+              onLocationInputChange('');
+            }}
+            onBlur={() => {
+              onLocationBlur(selectedLocation?.name ?? '');
+            }}
+            renderOption={(props, option) => (
+              <li {...props} key={option.id}>
+                {option.name}
+              </li>
+            )}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Location"
+                data-testid={`inline-location-${item.id}`}
+                inputRef={(el) => {
+                  setLocationRef(el, rowKey);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    const bestMatch = filteredOptions[0];
+                    if (bestMatch) {
+                      onDraftChange({ locationId: bestMatch.id });
+                      onLocationInputChange(bestMatch.name);
+                      onLocationBlur(bestMatch.name);
+                      onErrorChange(null);
+                      focusController.focus(rowKey, 'quantity');
+                    } else {
+                      onErrorChange('No matches found');
+                    }
+                  }
+                }}
+              />
+            )}
+          />
+        )}
+      </Stack>
+      <Stack spacing={density === 'compact' ? 0.25 : 0.5}>
+        {density !== 'compact' ? (
+          <>
+            <Typography variant="body2" color="text.secondary">
+              Quantity
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 700, letterSpacing: 0.1 }}>
+              {Number(item.quantity).toLocaleString()}
+            </Typography>
+          </>
+        ) : (
+          <TextField
+            type="text"
+            size="small"
+            data-testid={`inline-quantity-${item.id}`}
+            value={inlineDraft.quantity}
+            onChange={(e) => {
+              const raw = e.target.value.trim();
+              if (raw === '') {
+                onDraftChange({ quantity: '' });
+                onErrorChange('Quantity is required');
+                return;
+              }
+              const numeric = Number(raw);
+              onDraftChange({ quantity: Number.isNaN(numeric) ? '' : numeric });
+              if (!Number.isInteger(numeric) || numeric <= 0) {
+                onErrorChange('Quantity must be an integer greater than 0');
+              } else {
+                onErrorChange(null);
+              }
+            }}
+            inputProps={{
+              inputMode: 'numeric',
+              pattern: '[0-9]*',
+            }}
+            inputRef={(el) => {
+              setQuantityRef(el, rowKey);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                focusController.focus(rowKey, 'save');
+              }
+            }}
+            sx={{
+              maxWidth: 120,
+              '& input': {
+                MozAppearance: 'textfield',
+              },
+              '& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button': {
+                WebkitAppearance: 'none',
+                margin: 0,
+              },
+            }}
+          />
+        )}
+      </Stack>
+      <Stack spacing={density === 'compact' ? 0.25 : 0.5}>
+        {density !== 'compact' && (
+          <Typography variant="body2" color="text.secondary">
+            Updated
+          </Typography>
+        )}
+        <Typography variant="body2">
+          {new Date(item.dateModified || item.dateAdded || '').toLocaleDateString()}
+        </Typography>
+        {Number.isFinite(draftQuantityNumber) && draftQuantityNumber > 100000 && (
+          <Typography variant="caption" sx={{ color: 'warning.main' }}>
+            Large quantity entered - verify value.
+          </Typography>
+        )}
+        {inlineError && (
+          <Typography variant="caption" color="error">
+            {inlineError}
+          </Typography>
+        )}
+      </Stack>
+      <Stack
+        direction="row"
+        spacing={density === 'compact' ? 0.5 : 1}
+        justifyContent="flex-end"
+        alignItems="center"
+        sx={{
+          minWidth: density === 'compact' ? 140 : undefined,
+          flexWrap: 'nowrap',
+        }}
+      >
+        {density === 'compact' && isDirty && (
+          <Chip
+            label="Unsaved"
+            size="small"
+            color="warning"
+            variant="outlined"
+            sx={{ height: 22, fontSize: 12, flexShrink: 0 }}
+          />
+        )}
+        {density === 'compact' ? (
+          <IconButton
+            color="primary"
+            size="small"
+            onClick={onSave}
+            disabled={inlineSaving}
+            data-testid={`inline-save-${item.id}`}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                onSave();
+              }
+            }}
+            ref={(el: HTMLButtonElement | null) => {
+              setSaveRef(el, rowKey);
+            }}
+          >
+            <CheckIcon fontSize="small" />
+          </IconButton>
+        ) : (
+          <Tooltip title="Actions">
+            <IconButton onClick={onOpenActions}>
+              <MoreVertIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+export default InventoryInlineRow;

--- a/frontend/src/components/inventory/InventoryNewRow.tsx
+++ b/frontend/src/components/inventory/InventoryNewRow.tsx
@@ -1,0 +1,299 @@
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import type { RefObject } from 'react';
+import type { CatalogItem } from '../../services/uex.service';
+
+interface LocationOption {
+  id: number;
+  name: string;
+}
+
+interface InventoryNewRowProps {
+  isEditorMode: boolean;
+  itemOptions: CatalogItem[];
+  itemInput: string;
+  selectedItem: CatalogItem | null;
+  itemLoading: boolean;
+  itemError: string | null;
+  locationInput: string;
+  locationEditing: boolean;
+  selectedLocation: LocationOption | null;
+  filteredLocations: LocationOption[];
+  draft: { itemId: number | ''; locationId: number | ''; quantity: number | '' };
+  errors: {
+    item?: string | null;
+    location?: string | null;
+    quantity?: string | null;
+    org?: string | null;
+    api?: string | null;
+  };
+  dirty: boolean;
+  saving: boolean;
+  orgBlocked: boolean;
+  showQuantityWarning: boolean;
+  onItemInputChange: (value: string, reason: string) => void;
+  onItemSelect: (item: CatalogItem | null) => void;
+  onLocationInputChange: (value: string) => void;
+  onLocationSelect: (location: LocationOption | null) => void;
+  onLocationEnter: (bestMatch: LocationOption | undefined) => void;
+  onLocationFocus: () => void;
+  onLocationBlur: (value: string) => void;
+  onQuantityChange: (value: string) => void;
+  onQuantityEnter: () => void;
+  onSave: () => void;
+  onRetry: () => void;
+  itemRef: RefObject<HTMLInputElement | null>;
+  locationRef: RefObject<HTMLInputElement | null>;
+  quantityRef: RefObject<HTMLInputElement | null>;
+  saveRef: RefObject<HTMLButtonElement | null>;
+}
+
+export const InventoryNewRow = ({
+  isEditorMode,
+  itemOptions,
+  itemInput,
+  selectedItem,
+  itemLoading,
+  itemError,
+  locationInput,
+  locationEditing,
+  selectedLocation,
+  filteredLocations,
+  draft,
+  errors,
+  dirty,
+  saving,
+  orgBlocked,
+  showQuantityWarning,
+  onItemInputChange,
+  onItemSelect,
+  onLocationInputChange,
+  onLocationSelect,
+  onLocationEnter,
+  onLocationFocus,
+  onLocationBlur,
+  onQuantityChange,
+  onQuantityEnter,
+  onSave,
+  onRetry,
+  itemRef,
+  locationRef,
+  quantityRef,
+  saveRef,
+}: InventoryNewRowProps) => {
+  if (!isEditorMode) return null;
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: '1fr',
+          md: '2fr 1fr 1fr 1fr auto',
+        },
+        gap: 0.75,
+        alignItems: 'flex-start',
+        px: 1,
+        py: 0.75,
+        border: '1px dashed rgba(255,255,255,0.15)',
+        borderRadius: 2,
+        backgroundColor: 'rgba(255,255,255,0.02)',
+        mb: 1.5,
+      }}
+    >
+      <Stack spacing={0.5}>
+        <Autocomplete
+          size="small"
+          fullWidth
+          options={itemOptions}
+          value={selectedItem}
+          inputValue={itemInput}
+          loading={itemLoading}
+          autoHighlight
+          openOnFocus
+          filterOptions={(options) => options}
+          getOptionLabel={(option) => option?.name ?? ''}
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          onChange={(_, value) => onItemSelect(value)}
+          onInputChange={(_, value, reason) => onItemInputChange(value, reason)}
+          renderOption={(props, option) => (
+            <li {...props} key={option.id}>
+              <Stack spacing={0.25}>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  {option.name}
+                </Typography>
+                {option.categoryName && (
+                  <Typography variant="caption" color="text.secondary">
+                    {option.categoryName}
+                  </Typography>
+                )}
+              </Stack>
+            </li>
+          )}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="New item"
+              data-testid="new-row-item-input"
+              inputRef={itemRef as RefObject<HTMLInputElement>}
+              error={Boolean(errors.item)}
+              helperText={errors.item || itemError || undefined}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  onSave();
+                }
+              }}
+            />
+          )}
+        />
+      </Stack>
+      <Stack spacing={0.5}>
+        <Autocomplete
+          size="small"
+          fullWidth
+          options={filteredLocations}
+          autoHighlight
+          openOnFocus
+          filterOptions={(options) => options}
+          value={locationEditing ? null : selectedLocation}
+          inputValue={
+            locationEditing ? locationInput : selectedLocation?.name ?? locationInput
+          }
+          getOptionLabel={(option) => option?.name ?? ''}
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          onChange={(_, value) => onLocationSelect(value)}
+          onInputChange={(_, value) => onLocationInputChange(value)}
+          onFocus={onLocationFocus}
+          onBlur={() => onLocationBlur(selectedLocation?.name ?? '')}
+          renderOption={(props, option) => (
+            <li {...props} key={option.id}>
+              {option.name}
+            </li>
+          )}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Location"
+              data-testid="new-row-location-input"
+              inputRef={locationRef as RefObject<HTMLInputElement>}
+              error={Boolean(errors.location)}
+              helperText={errors.location || undefined}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  onLocationEnter(filteredLocations[0]);
+                }
+              }}
+            />
+          )}
+        />
+      </Stack>
+      <Stack spacing={0.5}>
+        <TextField
+          type="text"
+          size="small"
+          label="Quantity"
+          data-testid="new-row-quantity"
+          value={draft.quantity}
+          onChange={(e) => onQuantityChange(e.target.value)}
+          inputProps={{
+            inputMode: 'numeric',
+            pattern: '[0-9]*',
+          }}
+          inputRef={quantityRef as RefObject<HTMLInputElement>}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              onQuantityEnter();
+            }
+          }}
+          error={Boolean(errors.quantity)}
+          helperText={errors.quantity || undefined}
+        />
+        {showQuantityWarning && (
+          <Typography variant="caption" sx={{ color: 'warning.main' }}>
+            Large quantity entered - verify value.
+          </Typography>
+        )}
+      </Stack>
+      <Stack spacing={0.5}>
+        <Typography variant="body2" color="text.secondary">
+          New entry
+        </Typography>
+        {errors.org && (
+          <Typography variant="caption" color="error">
+            {errors.org}
+          </Typography>
+        )}
+        {errors.api && (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="caption" color="error">
+              {errors.api}
+            </Typography>
+            <Button
+              size="small"
+              color="inherit"
+              variant="text"
+              onClick={onRetry}
+              data-testid="new-row-retry"
+            >
+              Retry
+            </Button>
+          </Stack>
+        )}
+      </Stack>
+      <Stack
+        direction="row"
+        spacing={1}
+        justifyContent="flex-end"
+        alignItems="center"
+        sx={{ minWidth: 140 }}
+      >
+        {dirty && (
+          <Chip
+            label={saving ? 'Saving...' : 'Unsaved'}
+            size="small"
+            color={saving ? 'primary' : 'warning'}
+            variant="outlined"
+            sx={{ height: 22, fontSize: 12 }}
+          />
+        )}
+        <Tooltip
+          title={orgBlocked ? 'Select an organization to save items in org view.' : ''}
+          disableHoverListener={!orgBlocked}
+        >
+          <span>
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              onClick={onSave}
+              disabled={saving || orgBlocked}
+              data-testid="new-row-save"
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  onSave();
+                }
+              }}
+              ref={saveRef as RefObject<HTMLButtonElement>}
+            >
+              Save
+            </Button>
+          </span>
+        </Tooltip>
+      </Stack>
+    </Box>
+  );
+};
+
+export default InventoryNewRow;


### PR DESCRIPTION
## Summary
- Extract reusable inventory components: InventoryInlineRow, InventoryNewRow, and InventoryFiltersPanel for shared inline editing, new-row entry, and filter/view controls.
- Wire Inventory page to use the new components while preserving Editor Mode behaviors: focus transitions, org guardrail, retry/dirty states, and validation messaging.
- Keep inline actions/focus, new-row retry, and org blocking intact; clean up page-level code for reuse.

## Testing
- pnpm --filter frontend lint
- pnpm --filter frontend build
- pnpm --filter frontend test -- --runTestsByPath frontend/src/pages/Inventory.editor-mode.test.tsx
