### PR TITLE
fix: editor mode validation and keyboard tests

### DIFF
--- a/frontend/src/components/inventory/InventoryInlineRow.tsx
+++ b/frontend/src/components/inventory/InventoryInlineRow.tsx
@@ -15,6 +15,8 @@ import type { InventoryItem, OrgInventoryItem } from '../../services/inventory.s
 import type { FocusController } from '../../utils/focusController';
 import { useMemoizedLocations } from '../../hooks/useMemoizedLocations';
 
+const EDITOR_MODE_QUANTITY_MAX = 100000;
+
 export type InventoryRecord = InventoryItem | OrgInventoryItem;
 
 interface LocationOption {
@@ -234,7 +236,11 @@ export const InventoryInlineRow = ({
                 return;
               }
               const numeric = Number(raw);
-              onDraftChange({ quantity: Number.isNaN(numeric) ? '' : numeric });
+              if (Number.isNaN(numeric)) {
+                onDraftChange({ quantity: '' });
+              } else {
+                onDraftChange({ quantity: Math.min(numeric, EDITOR_MODE_QUANTITY_MAX) });
+              }
               if (!Number.isInteger(numeric) || numeric <= 0) {
                 onErrorChange('Quantity must be an integer greater than 0');
               } else {
@@ -276,7 +282,7 @@ export const InventoryInlineRow = ({
         <Typography variant="body2">
           {new Date(item.dateModified || item.dateAdded || '').toLocaleDateString()}
         </Typography>
-        {Number.isFinite(draftQuantityNumber) && draftQuantityNumber > 100000 && (
+        {Number.isFinite(draftQuantityNumber) && draftQuantityNumber >= EDITOR_MODE_QUANTITY_MAX && (
           <Typography variant="caption" sx={{ color: 'warning.main' }}>
             Large quantity entered - verify value.
           </Typography>

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -59,6 +59,7 @@ type InventoryRecord = InventoryItem | OrgInventoryItem;
 type ActionMode = 'edit' | 'split' | 'share' | 'delete' | null;
 
 const GAME_ID = 1;
+const EDITOR_MODE_QUANTITY_MAX = 100000;
 
 const valueText = (value: number) => `${value.toLocaleString()} qty`;
 
@@ -1715,7 +1716,8 @@ const InventoryPage = () => {
                       saving={newRowSaving}
                       orgBlocked={newRowOrgBlocked}
                       showQuantityWarning={
-                        Number.isFinite(newRowQuantityNumber) && newRowQuantityNumber > 100000
+                        Number.isFinite(newRowQuantityNumber) &&
+                        newRowQuantityNumber >= EDITOR_MODE_QUANTITY_MAX
                       }
                       onItemInputChange={(value, reason) => {
                         setNewRowItemInput(value);
@@ -1789,9 +1791,12 @@ const InventoryPage = () => {
                           return;
                         }
                         const numeric = Number(raw);
+                        const nextQuantity = Number.isNaN(numeric)
+                          ? ''
+                          : Math.min(numeric, EDITOR_MODE_QUANTITY_MAX);
                         setNewRowDraft((prev) => ({
                           ...prev,
-                          quantity: Number.isNaN(numeric) ? '' : numeric,
+                          quantity: nextQuantity,
                         }));
                         if (!Number.isInteger(numeric) || numeric <= 0) {
                           setNewRowErrors((prev) => ({


### PR DESCRIPTION
## Summary
  - cap editor-mode quantity at 100000 with warning threshold
  - add editor-mode keyboard, debounce, focus, and a11y tests
  - cover invalid location blocking and pagination focus boundary