### PR TITLE
feat: add org catalog item flow for inventory

### DIFF
--- a/backend/src/modules/org-inventory/org-inventory.controller.spec.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.spec.ts
@@ -76,4 +76,21 @@ describe('OrgInventoryController', () => {
       new BadRequestException('offset must be greater than or equal to 0'),
     );
   });
+
+  it('throws a bad request for non-integer id-like filters', async () => {
+    await expect(
+      controller.list({ user: { userId: 7 } }, 42, {
+        gameId: '1.5',
+      }),
+    ).rejects.toThrow(new BadRequestException('game_id must be an integer'));
+
+    await expect(
+      controller.list({ user: { userId: 7 } }, 42, {
+        gameId: '1',
+        locationId: '2.5',
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('location_id must be an integer'),
+    );
+  });
 });

--- a/backend/src/modules/org-inventory/org-inventory.controller.spec.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.spec.ts
@@ -1,0 +1,61 @@
+import { BadRequestException } from '@nestjs/common';
+import { OrgInventoryController } from './org-inventory.controller';
+import { OrgInventoryService } from './org-inventory.service';
+
+describe('OrgInventoryController', () => {
+  let controller: OrgInventoryController;
+  let orgInventoryService: jest.Mocked<Pick<OrgInventoryService, 'search'>>;
+
+  beforeEach(() => {
+    orgInventoryService = {
+      search: jest.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 25,
+        offset: 0,
+      }),
+    };
+
+    controller = new OrgInventoryController(
+      orgInventoryService as unknown as OrgInventoryService,
+    );
+  });
+
+  it('accepts camelCase query aliases for org inventory filters', async () => {
+    await controller.list({ user: { userId: 7 } }, 42, {
+      gameId: '1',
+      categoryId: '5',
+      uexItemId: '9',
+      locationId: '12',
+      minQuantity: '0.25',
+      maxQuantity: '10.5',
+      limit: '25',
+      offset: '50',
+    });
+
+    expect(orgInventoryService.search).toHaveBeenCalledWith(7, {
+      orgId: 42,
+      gameId: 1,
+      categoryId: 5,
+      uexItemId: 9,
+      locationId: 12,
+      search: undefined,
+      limit: 25,
+      offset: 50,
+      sort: undefined,
+      order: undefined,
+      activeOnly: undefined,
+      minQuantity: 0.25,
+      maxQuantity: 10.5,
+    });
+  });
+
+  it('throws a bad request for invalid numeric pagination params', async () => {
+    await expect(
+      controller.list({ user: { userId: 7 } }, 42, {
+        gameId: '1',
+        limit: 'abc',
+      }),
+    ).rejects.toThrow(new BadRequestException('limit must be a number'));
+  });
+});

--- a/backend/src/modules/org-inventory/org-inventory.controller.spec.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.spec.ts
@@ -58,4 +58,22 @@ describe('OrgInventoryController', () => {
       }),
     ).rejects.toThrow(new BadRequestException('limit must be a number'));
   });
+
+  it('throws a bad request for non-integer or out-of-range pagination params', async () => {
+    await expect(
+      controller.list({ user: { userId: 7 } }, 42, {
+        gameId: '1',
+        limit: '10.5',
+      }),
+    ).rejects.toThrow(new BadRequestException('limit must be an integer'));
+
+    await expect(
+      controller.list({ user: { userId: 7 } }, 42, {
+        gameId: '1',
+        offset: '-1',
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('offset must be greater than or equal to 0'),
+    );
+  });
 });

--- a/backend/src/modules/org-inventory/org-inventory.controller.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.ts
@@ -43,6 +43,10 @@ export class OrgInventoryController {
     query: Record<string, any>,
     keys: string[],
     fieldName: string,
+    options?: {
+      integer?: boolean;
+      min?: number;
+    },
   ): number | undefined {
     const rawValue = keys
       .map((key) => query[key])
@@ -55,6 +59,16 @@ export class OrgInventoryController {
     const parsedValue = Number(rawValue);
     if (Number.isNaN(parsedValue)) {
       throw new BadRequestException(`${fieldName} must be a number`);
+    }
+
+    if (options?.integer && !Number.isInteger(parsedValue)) {
+      throw new BadRequestException(`${fieldName} must be an integer`);
+    }
+
+    if (options?.min !== undefined && parsedValue < options.min) {
+      throw new BadRequestException(
+        `${fieldName} must be greater than or equal to ${options.min}`,
+      );
     }
 
     return parsedValue;
@@ -108,8 +122,14 @@ export class OrgInventoryController {
         'location_id',
       ),
       search: query.search,
-      limit: this.readOptionalNumber(query, ['limit'], 'limit'),
-      offset: this.readOptionalNumber(query, ['offset'], 'offset'),
+      limit: this.readOptionalNumber(query, ['limit'], 'limit', {
+        integer: true,
+        min: 1,
+      }),
+      offset: this.readOptionalNumber(query, ['offset'], 'offset', {
+        integer: true,
+        min: 0,
+      }),
       sort: query.sort,
       order: query.order,
       activeOnly:

--- a/backend/src/modules/org-inventory/org-inventory.controller.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.ts
@@ -101,6 +101,10 @@ export class OrgInventoryController {
       query,
       ['game_id', 'gameId'],
       'game_id',
+      {
+        integer: true,
+        min: 1,
+      },
     );
 
     const searchDto: OrgInventorySearchDto = {
@@ -110,16 +114,28 @@ export class OrgInventoryController {
         query,
         ['category_id', 'categoryId'],
         'category_id',
+        {
+          integer: true,
+          min: 1,
+        },
       ),
       uexItemId: this.readOptionalNumber(
         query,
         ['uex_item_id', 'uexItemId'],
         'uex_item_id',
+        {
+          integer: true,
+          min: 1,
+        },
       ),
       locationId: this.readOptionalNumber(
         query,
         ['location_id', 'locationId'],
         'location_id',
+        {
+          integer: true,
+          min: 1,
+        },
       ),
       search: query.search,
       limit: this.readOptionalNumber(query, ['limit'], 'limit', {

--- a/backend/src/modules/org-inventory/org-inventory.controller.ts
+++ b/backend/src/modules/org-inventory/org-inventory.controller.ts
@@ -39,6 +39,27 @@ import {
 export class OrgInventoryController {
   constructor(private readonly orgInventoryService: OrgInventoryService) {}
 
+  private readOptionalNumber(
+    query: Record<string, any>,
+    keys: string[],
+    fieldName: string,
+  ): number | undefined {
+    const rawValue = keys
+      .map((key) => query[key])
+      .find((value) => value !== undefined);
+
+    if (rawValue === undefined || rawValue === '') {
+      return undefined;
+    }
+
+    const parsedValue = Number(rawValue);
+    if (Number.isNaN(parsedValue)) {
+      throw new BadRequestException(`${fieldName} must be a number`);
+    }
+
+    return parsedValue;
+  }
+
   /**
    * List org inventory items with filtering
    * GET /api/orgs/:orgId/inventory
@@ -62,22 +83,33 @@ export class OrgInventoryController {
     offset: number;
   }> {
     const userId = req.user.userId;
-    const parsedMinQuantity = Number(
-      query.min_quantity ?? query.minQuantity ?? Number.NaN,
-    );
-    const parsedMaxQuantity = Number(
-      query.max_quantity ?? query.maxQuantity ?? Number.NaN,
+    const gameId = this.readOptionalNumber(
+      query,
+      ['game_id', 'gameId'],
+      'game_id',
     );
 
     const searchDto: OrgInventorySearchDto = {
       orgId,
-      gameId: Number(query.game_id ?? query.gameId),
-      categoryId: query.category_id ? Number(query.category_id) : undefined,
-      uexItemId: query.uex_item_id ? Number(query.uex_item_id) : undefined,
-      locationId: query.location_id ? Number(query.location_id) : undefined,
+      gameId: gameId ?? 0,
+      categoryId: this.readOptionalNumber(
+        query,
+        ['category_id', 'categoryId'],
+        'category_id',
+      ),
+      uexItemId: this.readOptionalNumber(
+        query,
+        ['uex_item_id', 'uexItemId'],
+        'uex_item_id',
+      ),
+      locationId: this.readOptionalNumber(
+        query,
+        ['location_id', 'locationId'],
+        'location_id',
+      ),
       search: query.search,
-      limit: query.limit ? Number(query.limit) : undefined,
-      offset: query.offset ? Number(query.offset) : undefined,
+      limit: this.readOptionalNumber(query, ['limit'], 'limit'),
+      offset: this.readOptionalNumber(query, ['offset'], 'offset'),
       sort: query.sort,
       order: query.order,
       activeOnly:
@@ -86,12 +118,16 @@ export class OrgInventoryController {
           : query.activeOnly !== undefined
             ? query.activeOnly === 'true' || query.activeOnly === true
             : undefined,
-      minQuantity: Number.isNaN(parsedMinQuantity)
-        ? undefined
-        : parsedMinQuantity,
-      maxQuantity: Number.isNaN(parsedMaxQuantity)
-        ? undefined
-        : parsedMaxQuantity,
+      minQuantity: this.readOptionalNumber(
+        query,
+        ['min_quantity', 'minQuantity'],
+        'min_quantity',
+      ),
+      maxQuantity: this.readOptionalNumber(
+        query,
+        ['max_quantity', 'maxQuantity'],
+        'max_quantity',
+      ),
     };
 
     if (!searchDto.gameId) {

--- a/backend/src/modules/org-inventory/org-inventory.repository.ts
+++ b/backend/src/modules/org-inventory/org-inventory.repository.ts
@@ -90,6 +90,26 @@ export class OrgInventoryRepository extends Repository<OrgInventoryItem> {
   }
 
   /**
+   * Find an existing org inventory item with matching composite keys
+   */
+  async findExistingItem(params: {
+    orgId: number;
+    gameId: number;
+    uexItemId: number;
+    locationId: number;
+  }): Promise<OrgInventoryItem | null> {
+    return this.findOne({
+      where: {
+        orgId: params.orgId,
+        gameId: params.gameId,
+        uexItemId: params.uexItemId,
+        locationId: params.locationId,
+        deleted: false,
+      },
+    });
+  }
+
+  /**
    * Soft delete an inventory item
    */
   async softDeleteItem(id: string, modifiedBy: number): Promise<boolean> {
@@ -227,10 +247,10 @@ export class OrgInventoryRepository extends Repository<OrgInventoryItem> {
       case 'location':
         return 'location.displayName';
       case 'date_added':
-        return 'oii.date_added';
+        return 'oii.dateAdded';
       case 'date_modified':
       default:
-        return 'oii.date_modified';
+        return 'oii.dateModified';
     }
   }
 }

--- a/backend/src/modules/org-inventory/org-inventory.service.ts
+++ b/backend/src/modules/org-inventory/org-inventory.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  ConflictException,
 } from '@nestjs/common';
 import { OrgInventoryRepository } from './org-inventory.repository';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -87,6 +88,19 @@ export class OrgInventoryService {
     }
 
     await this.verifyInventoryPermission(userId, dto.orgId, 'manage');
+
+    const existing = await this.orgInventoryRepository.findExistingItem({
+      orgId: dto.orgId,
+      gameId: dto.gameId,
+      uexItemId: dto.uexItemId,
+      locationId: dto.locationId,
+    });
+
+    if (existing) {
+      throw new ConflictException(
+        'Inventory item already exists for this organization and location',
+      );
+    }
 
     const item = this.orgInventoryRepository.create({
       ...dto,

--- a/frontend/src/components/inventory/InventoryFiltersPanel.tsx
+++ b/frontend/src/components/inventory/InventoryFiltersPanel.tsx
@@ -55,9 +55,11 @@ interface FiltersPanelProps {
   userInitial: string;
   onOpenAddDialog: () => void;
   showAddButton: boolean;
+  addButtonLabel?: string;
   totalCount: number;
   itemCount: number;
   autoFocusSearch?: boolean;
+  disabled?: boolean;
 }
 
 export const InventoryFiltersPanel = ({
@@ -83,9 +85,11 @@ export const InventoryFiltersPanel = ({
   userInitial,
   onOpenAddDialog,
   showAddButton,
+  addButtonLabel = 'Add item',
   totalCount,
   itemCount,
   autoFocusSearch = false,
+  disabled = false,
 }: FiltersPanelProps) => {
   return (
     <>
@@ -97,6 +101,7 @@ export const InventoryFiltersPanel = ({
             placeholder="Prospector, Lorville, armors..."
             value={filters.search}
             autoFocus={autoFocusSearch}
+            disabled={disabled}
             onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value }))}
           />
         </Grid>
@@ -107,6 +112,7 @@ export const InventoryFiltersPanel = ({
               labelId="category-filter-label"
               label="Category"
               value={filters.categoryId}
+              disabled={disabled}
               onChange={(e) =>
                 setFilters((prev) => ({
                   ...prev,
@@ -132,6 +138,7 @@ export const InventoryFiltersPanel = ({
               labelId="location-filter-label"
               label="Location"
               value={filters.locationId}
+              disabled={disabled}
               onChange={(e) =>
                 setFilters((prev) => ({
                   ...prev,
@@ -159,6 +166,7 @@ export const InventoryFiltersPanel = ({
               value={filters.valueRange}
               min={0}
               max={Math.max(filters.valueRange[1], maxQuantity || 1000)}
+              disabled={disabled}
               onChange={(_, value) =>
                 setFilters((prev) => ({
                   ...prev,
@@ -177,6 +185,7 @@ export const InventoryFiltersPanel = ({
               labelId="org-selector-label"
               label="View"
               value={viewMode === 'personal' ? 'personal' : selectedOrgId ?? ''}
+              disabled={disabled}
               onChange={(e) => {
                 const value = e.target.value;
                 if (value === 'personal') {
@@ -214,28 +223,29 @@ export const InventoryFiltersPanel = ({
 
       <Grid container spacing={2} alignItems="center">
         <Grid item>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={filters.sharedOnly}
-                onChange={(e) =>
-                  setFilters((prev) => ({
-                    ...prev,
-                    sharedOnly: e.target.checked,
-                  }))
-                }
-                size="small"
-                disabled={viewMode === 'org'}
-              />
-            }
-            label="Shared only"
-          />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={filters.sharedOnly}
+                  onChange={(e) =>
+                    setFilters((prev) => ({
+                      ...prev,
+                      sharedOnly: e.target.checked,
+                    }))
+                  }
+                  size="small"
+                  disabled={disabled || viewMode === 'org'}
+                />
+              }
+              label="Shared only"
+            />
         </Grid>
         <Grid item>
           <Button
             startIcon={<SortIcon />}
             variant="outlined"
             color="inherit"
+            disabled={disabled}
             onClick={() => setSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))}
           >
             Sort: {sortBy} ({sortDir})
@@ -248,6 +258,7 @@ export const InventoryFiltersPanel = ({
               labelId="sort-by-label"
               label="Sort By"
               value={sortBy}
+              disabled={disabled}
               onChange={(e) => setSortBy(e.target.value as 'name' | 'quantity' | 'location' | 'date')}
             >
               <MenuItem value="date">Last updated</MenuItem>
@@ -264,6 +275,7 @@ export const InventoryFiltersPanel = ({
               labelId="group-by-label"
               label="Group By"
               value={groupBy}
+              disabled={disabled}
               onChange={(e) => setGroupBy(e.target.value as 'none' | 'category' | 'location' | 'share')}
               startAdornment={<GroupWorkIcon sx={{ mr: 1 }} />}
             >
@@ -279,6 +291,7 @@ export const InventoryFiltersPanel = ({
             variant="outlined"
             color="inherit"
             startIcon={<FilterAltIcon />}
+            disabled={disabled}
             onClick={() =>
               setFilters({
                 search: '',
@@ -299,6 +312,7 @@ export const InventoryFiltersPanel = ({
               labelId="density-select-label"
               label="View mode"
               value={density}
+              disabled={disabled}
               onChange={(e) => setDensity(e.target.value as 'standard' | 'compact')}
             >
               <MenuItem value="standard">Standard</MenuItem>
@@ -308,8 +322,8 @@ export const InventoryFiltersPanel = ({
         </Grid>
         {showAddButton && (
           <Grid item>
-            <Button variant="contained" onClick={onOpenAddDialog}>
-              Add item
+            <Button variant="contained" onClick={onOpenAddDialog} disabled={disabled}>
+              {addButtonLabel}
             </Button>
           </Grid>
         )}

--- a/frontend/src/components/inventory/InventoryInlineRow.tsx
+++ b/frontend/src/components/inventory/InventoryInlineRow.tsx
@@ -18,6 +18,7 @@ import type { FocusController } from '../../utils/focusController';
 import { useMemoizedLocations } from '../../hooks/useMemoizedLocations';
 
 const EDITOR_MODE_QUANTITY_MAX = 100000;
+const MIN_INVENTORY_QUANTITY = 0.01;
 
 export type InventoryRecord = InventoryItem | OrgInventoryItem;
 
@@ -340,16 +341,16 @@ const InventoryInlineRow = ({
                       quantity: Math.min(numeric, EDITOR_MODE_QUANTITY_MAX),
                     });
                   }
-                  if (!Number.isInteger(numeric) || numeric <= 0) {
-                    onErrorChange(item.id, 'Quantity must be an integer greater than 0');
+                  if (!Number.isFinite(numeric) || numeric < MIN_INVENTORY_QUANTITY) {
+                    onErrorChange(item.id, 'Quantity must be at least 0.01');
                   } else {
                     onErrorChange(item.id, null);
                   }
                 }}
                 onBlur={() => onQuantityBlur(rowKey)}
                 inputProps={{
-                  inputMode: 'numeric',
-                  pattern: '[0-9]*',
+                  inputMode: 'decimal',
+                  pattern: '[0-9]*\\.?[0-9]*',
                 }}
                 inputRef={(el) => {
                   setQuantityRef(el, rowKey);

--- a/frontend/src/components/inventory/InventoryInlineRow.tsx
+++ b/frontend/src/components/inventory/InventoryInlineRow.tsx
@@ -20,6 +20,13 @@ import { useMemoizedLocations } from '../../hooks/useMemoizedLocations';
 const EDITOR_MODE_QUANTITY_MAX = 100000;
 const MIN_INVENTORY_QUANTITY = 0.01;
 
+const normalizeDraftLocationId = (locationId: number | ''): number | '' =>
+  typeof locationId === 'string'
+    ? locationId === ''
+      ? ''
+      : Number(locationId)
+    : locationId;
+
 export type InventoryRecord = InventoryItem | OrgInventoryItem;
 
 interface LocationOption {
@@ -94,10 +101,7 @@ const InventoryInlineRow = ({
   setQuantityRef,
   setSaveRef,
 }: InventoryInlineRowProps) => {
-  const draftLocationId =
-    typeof inlineDraft.locationId === 'string'
-      ? Number(inlineDraft.locationId)
-      : inlineDraft.locationId;
+  const draftLocationId = normalizeDraftLocationId(inlineDraft.locationId);
 
   const { filtered: filteredOptions } = useMemoizedLocations(
     allLocations,
@@ -112,7 +116,7 @@ const InventoryInlineRow = ({
 
   const draftQuantityNumber = Number(inlineDraft.quantity);
   const displayQuantity =
-    Number.isFinite(draftQuantityNumber) && draftQuantityNumber > 0
+    Number.isFinite(draftQuantityNumber)
       ? draftQuantityNumber
       : Number(item.quantity);
 

--- a/frontend/src/hooks/useMemoizedLocations.ts
+++ b/frontend/src/hooks/useMemoizedLocations.ts
@@ -5,8 +5,13 @@ interface LocationOption {
   name: string;
 }
 
-export const useMemoizedLocations = (allLocations: LocationOption[], input: string) => {
+export const useMemoizedLocations = (
+  allLocations: LocationOption[],
+  input: string,
+  isActive: boolean,
+) => {
   const filtered = useMemo(() => {
+    if (!isActive) return [];
     const term = input.trim().toLowerCase();
     return allLocations
       .filter((opt) => opt.name.toLowerCase().includes(term))
@@ -21,11 +26,7 @@ export const useMemoizedLocations = (allLocations: LocationOption[], input: stri
         if (aIndex !== bIndex) return aIndex - bIndex;
         return a.name.localeCompare(b.name);
       });
-  }, [allLocations, input]);
+  }, [allLocations, input, isActive]);
 
-  const getSelected = (id: number | '') =>
-    typeof id === 'number' ? allLocations.find((loc) => loc.id === id) ?? null : null;
-
-  return { filtered, getSelected };
+  return { filtered };
 };
-

--- a/frontend/src/pages/Inventory.editor-mode.test.tsx
+++ b/frontend/src/pages/Inventory.editor-mode.test.tsx
@@ -7,19 +7,22 @@ import type { LocationRecord } from '../services/location.service';
 
 const mockUpdateItem = jest.fn();
 const mockGetInventory = jest.fn();
+const mockGetOrgInventory = jest.fn();
 const mockGetUserOrganizations = jest.fn();
 const mockCreateItem = jest.fn();
 const mockCreateOrgItem = jest.fn();
+const mockUpdateOrgItem = jest.fn();
 const mockSearchItems = jest.fn();
+const mockGetUserPermissions = jest.fn();
 
 jest.mock('../services/inventory.service', () => ({
   inventoryService: {
     getCategories: jest.fn().mockResolvedValue([]),
     getUserOrganizations: (...args: unknown[]) => mockGetUserOrganizations(...args),
     getInventory: (...args: unknown[]) => mockGetInventory(...args),
-    getOrgInventory: jest.fn(),
+    getOrgInventory: (...args: unknown[]) => mockGetOrgInventory(...args),
     updateItem: (...args: unknown[]) => mockUpdateItem(...args),
-    updateOrgItem: jest.fn(),
+    updateOrgItem: (...args: unknown[]) => mockUpdateOrgItem(...args),
     createItem: (...args: unknown[]) => mockCreateItem(...args),
     createOrgItem: (...args: unknown[]) => mockCreateOrgItem(...args),
     shareItem: jest.fn(),
@@ -40,6 +43,33 @@ jest.mock('../services/uex.service', () => ({
     searchItems: (...args: unknown[]) => mockSearchItems(...args),
     getStarSystems: jest.fn(),
   },
+}));
+jest.mock('../services/permissions.service', () => ({
+  OrgPermission: {
+    CAN_VIEW_ORG_INVENTORY: 'can_view_org_inventory',
+    CAN_EDIT_ORG_INVENTORY: 'can_edit_org_inventory',
+    CAN_ADMIN_ORG_INVENTORY: 'can_admin_org_inventory',
+    CAN_VIEW_MEMBER_SHARED_ITEMS: 'can_view_member_shared_items',
+  },
+  permissionsService: {
+    getUserPermissions: (...args: unknown[]) => mockGetUserPermissions(...args),
+  },
+}));
+jest.mock('../components/location/SystemLocationSelector', () => ({
+  __esModule: true,
+  default: ({
+    onChange,
+  }: {
+    onChange: (value: { systemId: string; locationId: string }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-system-location-selector"
+      onClick={() => onChange({ systemId: '1', locationId: '200' })}
+    >
+      Select Test Location
+    </button>
+  ),
 }));
 jest.mock('../hooks/useMemoizedLocations', () => {
   const original = jest.requireActual('../hooks/useMemoizedLocations');
@@ -69,8 +99,10 @@ describe('Inventory editor mode inline controls', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockGetInventory.mockResolvedValue({ items: [mockItem], total: 1, limit: 25, offset: 0 });
+    mockGetOrgInventory.mockResolvedValue({ items: [mockItem], total: 1, limit: 25, offset: 0 });
     mockGetUserOrganizations.mockResolvedValue([]);
     mockUpdateItem.mockResolvedValue({});
+    mockUpdateOrgItem.mockResolvedValue({});
     mockCreateItem.mockResolvedValue({});
     mockSearchItems.mockResolvedValue({
       items: [
@@ -85,6 +117,7 @@ describe('Inventory editor mode inline controls', () => {
       limit: 20,
       offset: 0,
     });
+    mockGetUserPermissions.mockResolvedValue(['can_edit_org_inventory']);
     const mockedLocationCache = locationCache as jest.Mocked<typeof locationCache>;
     const mockLocations: LocationRecord[] = [
       {
@@ -308,7 +341,7 @@ describe('Inventory editor mode inline controls', () => {
     await waitFor(() => expect(document.activeElement).toBe(itemInput));
   });
 
-  it('prevents non-integer quantities and shows error', async () => {
+  it('prevents quantities below the minimum and shows error', async () => {
     render(
       <MemoryRouter initialEntries={['/inventory']}>
         <InventoryPage />
@@ -330,12 +363,12 @@ describe('Inventory editor mode inline controls', () => {
     fireEvent.click(await screen.findByText('Test Location'));
 
     const quantityInput = screen.getByTestId('new-row-quantity');
-    fireEvent.change(quantityInput, { target: { value: '7.5' } });
+    fireEvent.change(quantityInput, { target: { value: '0' } });
     const saveButton = screen.getByTestId('new-row-save');
     fireEvent.click(saveButton);
 
     expect(mockCreateItem).not.toHaveBeenCalled();
-    expect(screen.getByText('Quantity must be an integer greater than 0')).toBeInTheDocument();
+    expect(screen.getByText('Quantity must be at least 0.01')).toBeInTheDocument();
   });
 
   it('keeps the row dirty and shows retry on API failure', async () => {
@@ -374,7 +407,7 @@ describe('Inventory editor mode inline controls', () => {
     await waitFor(() => expect(mockCreateItem).toHaveBeenCalledTimes(2));
   });
 
-  it('shows inline quantity validation error for non-integer input and focuses the field', async () => {
+  it('allows decimal inline quantities and saves them', async () => {
     render(
       <MemoryRouter initialEntries={['/inventory']}>
         <InventoryPage />
@@ -392,10 +425,110 @@ describe('Inventory editor mode inline controls', () => {
     fireEvent.click(screen.getByTestId('inline-save-item-1'));
 
     await waitFor(() =>
-      expect(screen.getByText('Quantity must be an integer greater than 0')).toBeInTheDocument(),
+      expect(mockUpdateItem).toHaveBeenCalledWith('item-1', {
+        locationId: 200,
+        quantity: 3.5,
+      }),
     );
-    await waitFor(() => expect(document.activeElement).toBe(quantityInput));
-    expect(mockUpdateItem).not.toHaveBeenCalled();
+  });
+
+  it('hides the org add flow when org permissions do not include edit/admin', async () => {
+    mockGetUserOrganizations.mockResolvedValue([
+      {
+        id: 1,
+        userId: 1,
+        organizationId: 42,
+        roleId: 1,
+        organization: { id: 42, name: 'Test Org' },
+      },
+    ]);
+    mockGetUserPermissions.mockResolvedValue(['can_view_org_inventory']);
+
+    render(
+      <MemoryRouter initialEntries={['/inventory']}>
+        <InventoryPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+
+    const viewSelect = screen.getByLabelText('View');
+    fireEvent.mouseDown(viewSelect);
+    fireEvent.click(await screen.findByText('Test Org'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('You do not have permission to add items to this organization.'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: 'Add org item' })).not.toBeInTheDocument();
+  });
+
+  it('handles org add conflicts by loading the existing item and merging quantities', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    mockGetUserOrganizations.mockResolvedValue([
+      {
+        id: 1,
+        userId: 1,
+        organizationId: 42,
+        roleId: 1,
+        organization: { id: 42, name: 'Test Org' },
+      },
+    ]);
+    mockGetUserPermissions.mockResolvedValue(['can_edit_org_inventory']);
+    mockGetOrgInventory
+      .mockResolvedValueOnce({ items: [mockItem], total: 1, limit: 25, offset: 0 })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'org-item-1',
+            orgId: 42,
+            gameId: 1,
+            uexItemId: 300,
+            locationId: 200,
+            quantity: 4,
+            notes: '',
+            active: true,
+            dateAdded: new Date().toISOString(),
+            dateModified: new Date().toISOString(),
+            itemName: 'New Catalog Item',
+            locationName: 'Test Location',
+          },
+        ],
+        total: 1,
+        limit: 1,
+        offset: 0,
+      })
+      .mockResolvedValue({ items: [mockItem], total: 1, limit: 25, offset: 0 });
+    mockCreateOrgItem.mockRejectedValueOnce({ response: { status: 409 } });
+
+    render(
+      <MemoryRouter initialEntries={['/inventory']}>
+        <InventoryPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+
+    const viewSelect = screen.getByLabelText('View');
+    fireEvent.mouseDown(viewSelect);
+    fireEvent.click(await screen.findByText('Test Org'));
+
+    const addButton = await screen.findByRole('button', { name: 'Add org item' });
+    fireEvent.click(addButton);
+
+    fireEvent.click(await screen.findByText('New Catalog Item'));
+    fireEvent.click(screen.getByTestId('mock-system-location-selector'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add & close' }));
+
+    await waitFor(() =>
+      expect(mockUpdateOrgItem).toHaveBeenCalledWith(42, 'org-item-1', {
+        quantity: 5,
+        locationId: 200,
+      }),
+    );
+
+    confirmSpy.mockRestore();
   });
 
   it('focuses inline save on API failure', async () => {

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -45,6 +45,7 @@ import CallSplitIcon from '@mui/icons-material/CallSplit';
 import ShareIcon from '@mui/icons-material/Share';
 import UnpublishedIcon from '@mui/icons-material/Unpublished';
 import ViewAgendaIcon from '@mui/icons-material/ViewAgenda';
+import BusinessIcon from '@mui/icons-material/Business';
 import { inventoryService, InventoryCategory, InventoryItem, OrgInventoryItem } from '../services/inventory.service';
 import { uexService, CatalogItem } from '../services/uex.service';
 import { locationCache } from '../services/locationCache';
@@ -54,12 +55,37 @@ import { useFocusController } from '../hooks/useFocusController';
 import InventoryInlineRow from '../components/inventory/InventoryInlineRow';
 import InventoryNewRow from '../components/inventory/InventoryNewRow';
 import InventoryFiltersPanel from '../components/inventory/InventoryFiltersPanel';
+import { OrgPermission, permissionsService } from '../services/permissions.service';
 
 type InventoryRecord = InventoryItem | OrgInventoryItem;
 type ActionMode = 'edit' | 'split' | 'share' | 'delete' | null;
 
 const GAME_ID = 1;
 const EDITOR_MODE_QUANTITY_MAX = 100000;
+const ORG_ACCENT = '#f2a255';
+const VIEW_MODE_STORAGE_KEY = 'inventory:viewMode';
+const ORG_ID_STORAGE_KEY = 'inventory:selectedOrgId';
+const DENSITY_STORAGE_KEY = 'inventory:density';
+
+const readStoredViewMode = (): 'personal' | 'org' => {
+  if (typeof window === 'undefined') return 'personal';
+  const stored = window.sessionStorage.getItem(VIEW_MODE_STORAGE_KEY);
+  return stored === 'org' ? 'org' : 'personal';
+};
+
+const readStoredOrgId = (): number | null => {
+  if (typeof window === 'undefined') return null;
+  const stored = window.sessionStorage.getItem(ORG_ID_STORAGE_KEY);
+  if (!stored) return null;
+  const parsed = Number.parseInt(stored, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const readStoredDensity = (): 'standard' | 'compact' => {
+  if (typeof window === 'undefined') return 'standard';
+  const stored = window.sessionStorage.getItem(DENSITY_STORAGE_KEY);
+  return stored === 'compact' ? 'compact' : 'standard';
+};
 
 const valueText = (value: number) => `${value.toLocaleString()} qty`;
 
@@ -73,8 +99,8 @@ const InventoryPage = () => {
   const systemSelectRef = useRef<HTMLInputElement | null>(null);
   const [user, setUser] = useState<{ userId: number; username: string } | null>(null);
   const [orgOptions, setOrgOptions] = useState<{ id: number; name: string }[]>([]);
-  const [selectedOrgId, setSelectedOrgId] = useState<number | null>(null);
-  const [viewMode, setViewMode] = useState<'personal' | 'org'>('personal');
+  const [selectedOrgId, setSelectedOrgId] = useState<number | null>(() => readStoredOrgId());
+  const [viewMode, setViewMode] = useState<'personal' | 'org'>(() => readStoredViewMode());
   const [categories, setCategories] = useState<InventoryCategory[]>([]);
   const [items, setItems] = useState<InventoryRecord[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -93,7 +119,7 @@ const InventoryPage = () => {
   const [catalogItems, setCatalogItems] = useState<CatalogItem[]>([]);
   const [catalogTotal, setCatalogTotal] = useState(0);
   const [catalogPage, setCatalogPage] = useState(0);
-  const [catalogRowsPerPage, setCatalogRowsPerPage] = useState(10);
+  const [catalogRowsPerPage, setCatalogRowsPerPage] = useState(25);
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [selectedCatalogItem, setSelectedCatalogItem] = useState<CatalogItem | null>(null);
@@ -104,6 +130,9 @@ const InventoryPage = () => {
   const [newItemQuantity, setNewItemQuantity] = useState<number>(1);
   const [newItemNotes, setNewItemNotes] = useState('');
   const [addSubmitting, setAddSubmitting] = useState(false);
+  const [orgPermissions, setOrgPermissions] = useState<OrgPermission[]>([]);
+  const [orgPermissionsLoading, setOrgPermissionsLoading] = useState(false);
+  const [orgPermissionsError, setOrgPermissionsError] = useState<string | null>(null);
 
   const [filters, setFilters] = useState({
     search: '',
@@ -117,7 +146,7 @@ const InventoryPage = () => {
   const [groupBy, setGroupBy] = useState<'none' | 'category' | 'location' | 'share'>('none');
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(25);
-  const [density, setDensity] = useState<'standard' | 'compact'>('standard');
+  const [density, setDensity] = useState<'standard' | 'compact'>(() => readStoredDensity());
   const [inlineDrafts, setInlineDrafts] = useState<
     Record<string, { locationId: number | ''; quantity: number | '' }>
   >({});
@@ -125,8 +154,15 @@ const InventoryPage = () => {
   const [inlineSaved, setInlineSaved] = useState<Set<string>>(new Set());
   const [inlineError, setInlineError] = useState<Record<string, string | null>>({});
   const [allLocations, setAllLocations] = useState<{ id: number; name: string }[]>([]);
+  const locationNameById = useMemo(
+    () => new Map(allLocations.map((loc) => [loc.id, loc.name])),
+    [allLocations],
+  );
   const [inlineLocationInputs, setInlineLocationInputs] = useState<Record<string, string>>({});
-  const [locationEditing, setLocationEditing] = useState<Record<string, boolean>>({});
+  const [inlineActiveField, setInlineActiveField] = useState<{
+    rowKey: string;
+    field: 'location' | 'quantity';
+  } | null>(null);
   const [pendingFocusAfterPageChange, setPendingFocusAfterPageChange] = useState(false);
   const [newRowDraft, setNewRowDraft] = useState<{
     itemId: number | '';
@@ -154,6 +190,34 @@ const InventoryPage = () => {
   const [newRowSaving, setNewRowSaving] = useState(false);
   const debouncedSearch = useDebounce(filters.search, 350);
   const debouncedCatalogSearch = useDebounce(catalogSearch, 350);
+  const isOrgMode = viewMode === 'org';
+
+  useEffect(() => {
+    window.sessionStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+  }, [viewMode]);
+
+  useEffect(() => {
+    if (selectedOrgId === null) {
+      window.sessionStorage.removeItem(ORG_ID_STORAGE_KEY);
+      return;
+    }
+    window.sessionStorage.setItem(ORG_ID_STORAGE_KEY, selectedOrgId.toString());
+  }, [selectedOrgId]);
+
+  useEffect(() => {
+    window.sessionStorage.setItem(DENSITY_STORAGE_KEY, density);
+  }, [density]);
+
+  useEffect(() => {
+    if (orgOptions.length === 0 || selectedOrgId === null) return;
+    const isValidOrg = orgOptions.some((org) => org.id === selectedOrgId);
+    if (!isValidOrg) {
+      setSelectedOrgId(null);
+      if (viewMode === 'org') {
+        setViewMode('personal');
+      }
+    }
+  }, [orgOptions, selectedOrgId, viewMode]);
   const debouncedNewItemSearch = useDebounce(newRowItemInput, 300);
   const debouncedNewLocationSearch = useDebounce(newRowLocationInput, 200);
   const getRowOrder = useCallback(
@@ -187,6 +251,107 @@ const InventoryPage = () => {
   const newRowSaveRef = useRef<HTMLButtonElement | null>(null);
   const newRowItemCache = useRef<Map<string, CatalogItem[]>>(new Map());
 
+  const activateInlineField = useCallback(
+    (
+      rowKey: string,
+      field: 'location' | 'quantity',
+      initialInput?: string,
+    ) => {
+      setInlineActiveField({ rowKey, field });
+      if (field === 'location') {
+        setInlineLocationInputs((prev) => ({
+          ...prev,
+          [rowKey]: initialInput ?? prev[rowKey] ?? '',
+        }));
+      }
+      const parsedId = Number(rowKey);
+      if (!Number.isNaN(parsedId)) {
+        setInlineError((prev) => ({ ...prev, [parsedId]: null }));
+      }
+    },
+    [],
+  );
+  const handleInlineDraftChange = useCallback(
+    (itemId: string, changes: Partial<{ locationId: number | ''; quantity: number | '' }>) => {
+      setInlineDrafts((prev) => {
+        const nextLocation =
+          changes.locationId === undefined
+            ? prev[itemId]?.locationId ?? ''
+            : Number.isNaN(Number(changes.locationId))
+            ? ''
+            : (Number(changes.locationId) as number);
+        return {
+          ...prev,
+          [itemId]: {
+            locationId: nextLocation,
+            quantity:
+              changes.quantity === undefined
+                ? prev[itemId]?.quantity ?? 0
+                : (changes.quantity as number | ''),
+          },
+        };
+      });
+      setInlineError((prev) => ({ ...prev, [itemId]: null }));
+    },
+    [],
+  );
+  const handleInlineErrorChange = useCallback((itemId: string, message: string | null) => {
+    setInlineError((prev) => ({
+      ...prev,
+      [itemId]: message,
+    }));
+  }, []);
+  const handleInlineLocationInputChange = useCallback((rowKey: string, value: string) => {
+    setInlineLocationInputs((prev) => ({
+      ...prev,
+      [rowKey]: value,
+    }));
+  }, []);
+  const handleInlineLocationFocus = useCallback((itemId: string) => {
+    setInlineError((prev) => ({ ...prev, [itemId]: null }));
+  }, []);
+  const handleInlineLocationBlur = useCallback(
+    (
+      rowKey: string,
+      itemId: string,
+      draftLocationId: number | '',
+      selectedName?: string,
+    ) => {
+      setInlineLocationInputs((prev) => ({
+        ...prev,
+        [rowKey]:
+          selectedName ??
+          (Number.isFinite(draftLocationId)
+            ? locationNameById.get(draftLocationId as number)
+            : undefined) ??
+          '',
+      }));
+      setInlineError((prev) => ({ ...prev, [itemId]: null }));
+      setInlineActiveField((prev) => {
+        if (!prev || prev.rowKey !== rowKey) return prev;
+        if (prev.field !== 'location') return prev;
+        return null;
+      });
+    },
+    [locationNameById],
+  );
+  const handleInlineQuantityBlur = useCallback((rowKey: string) => {
+    setInlineActiveField((prev) => {
+      if (!prev || prev.rowKey !== rowKey) return prev;
+      if (prev.field !== 'quantity') return prev;
+      return null;
+    });
+  }, []);
+  const handleLocationRef = useCallback((ref: HTMLInputElement | null, key: string) => {
+    locationRefs.current[key] = ref;
+  }, []);
+  const handleQuantityRef = useCallback((ref: HTMLInputElement | null, key: string) => {
+    quantityRefs.current[key] = ref;
+  }, []);
+  const handleSaveRef = useCallback((ref: HTMLButtonElement | null, key: string) => {
+    saveRefs.current[key] = ref;
+  }, []);
+
   const handleLogout = () => {
     localStorage.removeItem('access_token');
     localStorage.removeItem('refresh_token');
@@ -199,10 +364,28 @@ const InventoryPage = () => {
     setActionMode(null);
   };
 
-  const handleActionOpen = (event: React.MouseEvent<HTMLElement>, item: InventoryRecord) => {
-    setActionAnchor(event.currentTarget);
-    setActionItem(item);
-  };
+  const handleActionOpen = useCallback(
+    (event: React.MouseEvent<HTMLElement>, item: InventoryRecord) => {
+      setActionAnchor(event.currentTarget);
+      setActionItem(item);
+    },
+    [],
+  );
+
+  const canManageOrgInventory = useMemo(
+    () =>
+      orgPermissions.includes(OrgPermission.CAN_EDIT_ORG_INVENTORY) ||
+      orgPermissions.includes(OrgPermission.CAN_ADMIN_ORG_INVENTORY),
+    [orgPermissions],
+  );
+  const showAddButton =
+    viewMode === 'personal' ||
+    (viewMode === 'org' && Boolean(selectedOrgId) && canManageOrgInventory);
+  const addButtonLabel = viewMode === 'org' ? 'Add org item' : 'Add item';
+  const selectedOrgName = useMemo(
+    () => orgOptions.find((org) => org.id === selectedOrgId)?.name ?? 'Organization',
+    [orgOptions, selectedOrgId],
+  );
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -311,7 +494,7 @@ const InventoryPage = () => {
       const limit = rowsPerPage;
       const offset = page * rowsPerPage;
 
-      if (viewMode === 'org' && selectedOrgId) {
+      if (isOrgMode && selectedOrgId) {
         const data = await inventoryService.getOrgInventory(selectedOrgId, {
           gameId: GAME_ID,
           search: debouncedSearch || undefined,
@@ -384,6 +567,10 @@ const InventoryPage = () => {
   ]);
 
   const openAddDialog = () => {
+    if (viewMode === 'org' && !canManageOrgInventory) {
+      setCatalogError('You do not have permission to add items to this organization.');
+      return;
+    }
     setAddDialogOpen(true);
     setSelectedCatalogItem(null);
     setCatalogSearch('');
@@ -401,8 +588,17 @@ const InventoryPage = () => {
   };
 
   const handleCreateInventoryItem = async (options?: { stayOpen?: boolean }) => {
+    const isOrgView = viewMode === 'org' && selectedOrgId !== null;
     if (!selectedCatalogItem) {
       setCatalogError('Select an item to add.');
+      return;
+    }
+    if (viewMode === 'org' && !selectedOrgId) {
+      setCatalogError('Select an organization.');
+      return;
+    }
+    if (viewMode === 'org' && !canManageOrgInventory) {
+      setCatalogError('You do not have permission to add items to this organization.');
       return;
     }
     if (destinationSelection.locationId === '') {
@@ -426,15 +622,27 @@ const InventoryPage = () => {
 
       if (existing) {
         const shouldMerge = window.confirm(
-          'An item with this location already exists. Merge quantities?',
+          isOrgView
+            ? 'This org already has this item at the selected location. Merge quantities?'
+            : 'An item with this location already exists. Merge quantities?',
         );
         if (shouldMerge) {
           const newQuantity =
             (Number(existing.quantity) || 0) + Number(newItemQuantity);
-          await inventoryService.updateItem(existing.id, {
-            quantity: newQuantity,
-            locationId: numericLocationId,
-          });
+          if (isOrgView && selectedOrgId !== null) {
+            await inventoryService.updateOrgItem(selectedOrgId, existing.id, {
+              quantity: newQuantity,
+              locationId: numericLocationId,
+            });
+          } else {
+            await inventoryService.updateItem(existing.id, {
+              quantity: newQuantity,
+              locationId: numericLocationId,
+            });
+          }
+        } else if (isOrgView) {
+          setCatalogError('This item already exists for the selected location.');
+          return;
         } else {
           await inventoryService.createItem({
             gameId: GAME_ID,
@@ -445,13 +653,23 @@ const InventoryPage = () => {
           });
         }
       } else {
-        await inventoryService.createItem({
-          gameId: GAME_ID,
-          uexItemId: selectedCatalogItem.uexId,
-          locationId: numericLocationId,
-          quantity: newItemQuantity,
-          notes: newItemNotes || undefined,
-        });
+        if (isOrgView && selectedOrgId !== null) {
+          await inventoryService.createOrgItem(selectedOrgId, {
+            gameId: GAME_ID,
+            uexItemId: selectedCatalogItem.uexId,
+            locationId: numericLocationId,
+            quantity: newItemQuantity,
+            notes: newItemNotes || undefined,
+          });
+        } else {
+          await inventoryService.createItem({
+            gameId: GAME_ID,
+            uexItemId: selectedCatalogItem.uexId,
+            locationId: numericLocationId,
+            quantity: newItemQuantity,
+            notes: newItemNotes || undefined,
+          });
+        }
       }
 
       await fetchInventory();
@@ -464,7 +682,45 @@ const InventoryPage = () => {
       }
     } catch (err) {
       console.error('Error adding inventory item', err);
-      setCatalogError('Unable to add item right now.');
+      const status = err && typeof err === 'object' && 'response' in err
+        ? (err as { response?: { status?: number } }).response?.status
+        : undefined;
+      if (status === 403) {
+        setCatalogError('You do not have permission to add items to this organization.');
+      } else if (status === 409 && viewMode === 'org' && selectedOrgId) {
+        const numericLocationId = Number(destinationSelection.locationId);
+        const existing = items.find(
+          (item) =>
+            item.uexItemId === selectedCatalogItem?.uexId &&
+            item.locationId === numericLocationId,
+        );
+        if (existing) {
+          const shouldMerge = window.confirm(
+            'This org already has this item at the selected location. Merge quantities?',
+          );
+          if (shouldMerge) {
+            const newQuantity =
+              (Number(existing.quantity) || 0) + Number(newItemQuantity);
+            await inventoryService.updateOrgItem(selectedOrgId, existing.id, {
+              quantity: newQuantity,
+              locationId: numericLocationId,
+            });
+            await fetchInventory();
+            if (options?.stayOpen) {
+              setNewItemQuantity(1);
+              setNewItemNotes('');
+              setCatalogError(null);
+            } else {
+              closeAddDialog();
+            }
+            setAddSubmitting(false);
+            return;
+          }
+        }
+        setCatalogError('This item already exists for the selected location.');
+      } else {
+        setCatalogError('Unable to add item right now.');
+      }
     } finally {
       setAddSubmitting(false);
     }
@@ -488,6 +744,39 @@ const InventoryPage = () => {
   }, [user, fetchOrganizations]);
 
   useEffect(() => {
+    if (viewMode !== 'org' || !user?.userId || !selectedOrgId) {
+      setOrgPermissions([]);
+      setOrgPermissionsError(null);
+      return;
+    }
+    let isMounted = true;
+    setOrgPermissionsLoading(true);
+    permissionsService
+      .getUserPermissions(user.userId, selectedOrgId)
+      .then((permissions) => {
+        if (isMounted) {
+          setOrgPermissions(permissions);
+          setOrgPermissionsError(null);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load org permissions', err);
+        if (isMounted) {
+          setOrgPermissions([]);
+          setOrgPermissionsError('Unable to load organization permissions.');
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setOrgPermissionsLoading(false);
+        }
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [viewMode, user?.userId, selectedOrgId]);
+
+  useEffect(() => {
     if (user) {
       fetchInventory();
     }
@@ -506,6 +795,12 @@ const InventoryPage = () => {
       fetchCatalog();
     }
   }, [addDialogOpen, fetchCatalog]);
+
+  useEffect(() => {
+    if (addDialogOpen && viewMode === 'org' && !canManageOrgInventory) {
+      setAddDialogOpen(false);
+    }
+  }, [addDialogOpen, viewMode, canManageOrgInventory]);
 
   useEffect(() => {
     if (!addDialogOpen) return;
@@ -650,29 +945,6 @@ const InventoryPage = () => {
   const isEditorMode = density === 'compact';
   const newRowOrgBlocked = viewMode === 'org' && !selectedOrgId;
 
-  const setInlineDraft = (
-    id: string,
-    changes: Partial<{ locationId: number | ''; quantity: number | '' }>,
-  ) => {
-    setInlineDrafts((prev) => {
-      const nextLocation =
-        changes.locationId === undefined
-          ? prev[id]?.locationId ?? ''
-          : Number.isNaN(Number(changes.locationId))
-          ? ''
-          : (Number(changes.locationId) as number);
-      return {
-        ...prev,
-        [id]: {
-          locationId: nextLocation,
-          quantity:
-            changes.quantity === undefined ? prev[id]?.quantity ?? 0 : (changes.quantity as number | ''),
-        },
-      };
-    });
-    setInlineError((prev) => ({ ...prev, [id]: null }));
-  };
-
   const resetNewRowDraft = () => {
     setNewRowDraft({
       itemId: '',
@@ -755,25 +1027,17 @@ const InventoryPage = () => {
     const unregisters: Array<() => void> = [];
     items.forEach((item) => {
       const key = item.id.toString();
-      const locationRef = locationRefs.current[key];
-      const quantityRef = quantityRefs.current[key];
+      unregisters.push(
+        focusController.register(key, 'location', () => {
+          activateInlineField(key, 'location');
+        }),
+      );
+      unregisters.push(
+        focusController.register(key, 'quantity', () => {
+          activateInlineField(key, 'quantity');
+        }),
+      );
       const saveRef = saveRefs.current[key];
-      if (locationRef) {
-        unregisters.push(
-          focusController.register(key, 'location', () => {
-            locationRef.focus();
-            locationRef.select?.();
-          }),
-        );
-      }
-      if (quantityRef) {
-        unregisters.push(
-          focusController.register(key, 'quantity', () => {
-            quantityRef.focus();
-            quantityRef.select?.();
-          }),
-        );
-      }
       if (saveRef) {
         unregisters.push(
           focusController.register(key, 'save', () => {
@@ -785,7 +1049,22 @@ const InventoryPage = () => {
     return () => {
       unregisters.forEach((fn) => fn());
     };
-  }, [items, focusController]);
+  }, [items, focusController, activateInlineField]);
+
+  useEffect(() => {
+    if (!inlineActiveField) return;
+    const { rowKey, field } = inlineActiveField;
+    const ref =
+      field === 'location'
+        ? locationRefs.current[rowKey]
+        : quantityRefs.current[rowKey];
+    if (!ref) return;
+    const handle = window.requestAnimationFrame(() => {
+      ref.focus();
+      ref.select?.();
+    });
+    return () => window.cancelAnimationFrame(handle);
+  }, [inlineActiveField]);
 
   useEffect(() => {
     const unregisters: Array<() => void> = [];
@@ -842,6 +1121,7 @@ const InventoryPage = () => {
   useEffect(() => {
     if (!isEditorMode) {
       resetNewRowDraft();
+      setInlineActiveField(null);
     }
   }, [isEditorMode]);
 
@@ -928,7 +1208,7 @@ const InventoryPage = () => {
     };
   }, [debouncedNewItemSearch, isEditorMode]);
 
-  const handleInlineSave = async (item: InventoryRecord) => {
+  const handleInlineSave = useCallback(async (item: InventoryRecord) => {
     const draft = inlineDrafts[item.id] ?? {
       locationId: item.locationId ?? '',
       quantity: Number(item.quantity) || 0,
@@ -965,8 +1245,7 @@ const InventoryPage = () => {
       ...item,
       locationId: parsedLocationId,
       quantity: parsedQuantity,
-      locationName:
-        allLocations.find((loc) => loc.id === parsedLocationId)?.name || item.locationName,
+      locationName: locationNameById.get(parsedLocationId) || item.locationName,
     };
     setItems((prev) =>
       prev.map((entry) => (entry.id === item.id ? updatedItem : entry)),
@@ -1013,9 +1292,18 @@ const InventoryPage = () => {
       updated.delete(item.id);
       setInlineSaving(updated);
     }
-  };
+  }, [
+    focusController,
+    inlineDrafts,
+    inlineSaving,
+    inventoryService,
+    isOrgMode,
+    items,
+    locationNameById,
+    selectedOrgId,
+  ]);
 
-  const handleInlineSaveAndAdvance = async (item: InventoryRecord) => {
+  const handleInlineSaveAndAdvance = useCallback(async (item: InventoryRecord) => {
     const saved = await handleInlineSave(item);
     if (saved) {
       const advanced = await focusController.focusNext(item.id.toString(), 'save');
@@ -1023,7 +1311,7 @@ const InventoryPage = () => {
         focusController.focus(items[0].id.toString(), 'location');
       }
     }
-  };
+  }, [focusController, handleInlineSave, items]);
 
   const openActionDialog = (mode: ActionMode) => {
     setActionMode(mode);
@@ -1461,6 +1749,7 @@ const InventoryPage = () => {
     );
   }
 
+  const inventoryBusy = refreshing;
   const showEmptyState = filteredItems.length === 0 && !refreshing;
   const renderInlineRow = (item: InventoryRecord) => {
     const rowKey = item.id.toString();
@@ -1475,13 +1764,17 @@ const InventoryPage = () => {
     const draftQuantityNumber = Number(draft.quantity);
     const isDirty =
       draftLocationId !== originalLocationId || draftQuantityNumber !== originalQuantity;
+    const isRowActive = inlineActiveField?.rowKey === rowKey;
+    const isLocationActive = isRowActive && inlineActiveField?.field === 'location';
+    const isQuantityActive = isRowActive && inlineActiveField?.field === 'quantity';
+    const resolvedLocationName = Number.isFinite(draftLocationId)
+      ? locationNameById.get(draftLocationId as number)
+      : undefined;
     const inlineLocationValue =
       inlineLocationInputs[rowKey] ??
-      (locationEditing[rowKey]
+      (isLocationActive
         ? ''
-        : allLocations.find((loc) => loc.id === (typeof draft.locationId === 'number' ? draft.locationId : Number(draft.locationId)))?.name ??
-          item.locationName ??
-          '');
+        : resolvedLocationName ?? item.locationName ?? '');
     const saving = inlineSaving.has(item.id);
     const errorText = inlineError[item.id];
     const saved = inlineSaved.has(item.id.toString());
@@ -1492,58 +1785,30 @@ const InventoryPage = () => {
         item={item}
         density={density}
         allLocations={allLocations}
+        locationNameById={locationNameById}
         inlineDraft={draft}
         inlineLocationInput={inlineLocationValue}
-        locationEditing={Boolean(locationEditing[rowKey])}
+        locationEditing={isLocationActive}
+        quantityEditing={isQuantityActive}
         inlineSaving={saving}
         inlineSaved={saved}
         inlineError={errorText}
         isDirty={isDirty}
+        isRowActive={isRowActive}
         focusController={focusController}
         rowKey={rowKey}
-        onDraftChange={(changes) => setInlineDraft(item.id, changes)}
-        onErrorChange={(message) =>
-          setInlineError((prev) => ({
-            ...prev,
-            [item.id]: message,
-          }))
-        }
-        onLocationInputChange={(value) =>
-          setInlineLocationInputs((prev) => ({
-            ...prev,
-            [rowKey]: value,
-          }))
-        }
-        onLocationFocus={() => {
-          setInlineLocationInputs((prev) => ({
-            ...prev,
-            [rowKey]: '',
-          }));
-          setLocationEditing((prev) => ({ ...prev, [rowKey]: true }));
-          setInlineError((prev) => ({ ...prev, [item.id]: null }));
-        }}
-        onLocationBlur={(selectedName) => {
-          setInlineLocationInputs((prev) => ({
-            ...prev,
-            [rowKey]:
-              selectedName ??
-              allLocations.find((loc) => loc.id === draftLocationId)?.name ??
-              '',
-          }));
-          setLocationEditing((prev) => ({ ...prev, [rowKey]: false }));
-          setInlineError((prev) => ({ ...prev, [item.id]: null }));
-        }}
-        onSave={() => handleInlineSaveAndAdvance(item)}
-        onOpenActions={(e) => handleActionOpen(e, item)}
-        setLocationRef={(ref, key) => {
-          locationRefs.current[key] = ref;
-        }}
-        setQuantityRef={(ref, key) => {
-          quantityRefs.current[key] = ref;
-        }}
-        setSaveRef={(ref, key) => {
-          saveRefs.current[key] = ref;
-        }}
+        onDraftChange={handleInlineDraftChange}
+        onErrorChange={handleInlineErrorChange}
+        onLocationInputChange={handleInlineLocationInputChange}
+        onLocationFocus={handleInlineLocationFocus}
+        onLocationBlur={handleInlineLocationBlur}
+        onQuantityBlur={handleInlineQuantityBlur}
+        onActivateField={activateInlineField}
+        onSave={handleInlineSaveAndAdvance}
+        onOpenActions={handleActionOpen}
+        setLocationRef={handleLocationRef}
+        setQuantityRef={handleQuantityRef}
+        setSaveRef={handleSaveRef}
       />
     );
   };
@@ -1586,8 +1851,75 @@ const InventoryPage = () => {
         </Toolbar>
       </AppBar>
 
-      <Container maxWidth="xl" sx={{ py: 4 }}>
-        <Grid container spacing={3}>
+      {isOrgMode && (
+        <Box
+          sx={{
+            background: 'rgba(242, 162, 85, 0.12)',
+            borderBottom: '1px solid rgba(242, 162, 85, 0.35)',
+            boxShadow: 'inset 0 -1px 0 rgba(0,0,0,0.2)',
+          }}
+        >
+          <Container maxWidth="xl" sx={{ py: 1.5 }}>
+            <Stack direction="row" spacing={1.5} alignItems="center">
+              <BusinessIcon sx={{ color: ORG_ACCENT }} fontSize="small" />
+              <Typography variant="subtitle2" sx={{ color: '#f7f1e8', fontWeight: 600 }}>
+                Organization mode
+              </Typography>
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{ borderColor: 'rgba(242, 162, 85, 0.35)' }}
+              />
+              <Typography variant="body2" sx={{ color: '#f0d9c0' }}>
+                {selectedOrgId ? `Working in ${selectedOrgName}` : 'Select an organization to continue.'}
+              </Typography>
+            </Stack>
+          </Container>
+        </Box>
+      )}
+
+      <Container
+        maxWidth="xl"
+        sx={{
+          py: 4,
+          mt: isOrgMode ? 2 : 0,
+          outline: isOrgMode ? '1px solid rgba(242, 162, 85, 0.35)' : 'none',
+          outlineOffset: isOrgMode ? 0 : undefined,
+          borderRadius: isOrgMode ? 3 : undefined,
+          boxShadow: isOrgMode
+            ? '0 0 0 1px rgba(242, 162, 85, 0.08), 0 0 24px rgba(242, 162, 85, 0.08)'
+            : 'none',
+          position: 'relative',
+        }}
+        aria-busy={inventoryBusy}
+      >
+        {inventoryBusy && (
+          <Box
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 5,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: 'rgba(11, 17, 24, 0.65)',
+              backdropFilter: 'blur(2px)',
+              borderRadius: isOrgMode ? 3 : 0,
+            }}
+          >
+            <Stack spacing={1} alignItems="center">
+              <CircularProgress color="inherit" size={28} />
+              <Typography variant="body2" color="text.secondary">
+                Loading inventory...
+              </Typography>
+            </Stack>
+          </Box>
+        )}
+        <Box sx={{ pointerEvents: inventoryBusy ? 'none' : 'auto' }}>
+          <Grid container spacing={3}>
           <Grid item xs={12}>
             <Card
               sx={{
@@ -1618,11 +1950,23 @@ const InventoryPage = () => {
                   orgOptions={orgOptions}
                   userInitial={user?.username?.charAt(0).toUpperCase() || 'U'}
                   onOpenAddDialog={openAddDialog}
-                  showAddButton={viewMode === 'personal'}
+                  showAddButton={showAddButton}
+                  addButtonLabel={addButtonLabel}
                   totalCount={totalCount}
                   itemCount={items.length}
                   autoFocusSearch
+                  disabled={inventoryBusy}
                 />
+                {viewMode === 'org' && selectedOrgId && !canManageOrgInventory && !orgPermissionsLoading && (
+                  <Alert severity="info" sx={{ mt: 2 }}>
+                    You do not have permission to add items to this organization.
+                  </Alert>
+                )}
+                {orgPermissionsError && (
+                  <Alert severity="warning" sx={{ mt: 2 }}>
+                    {orgPermissionsError}
+                  </Alert>
+                )}
               </CardContent>
             </Card>
           </Grid>
@@ -1873,13 +2217,20 @@ const InventoryPage = () => {
                       component="div"
                       count={totalCount}
                       page={page}
-                      onPageChange={(_, newPage) => setPage(newPage)}
+                      onPageChange={(_, newPage) => {
+                        if (inventoryBusy) return;
+                        setPage(newPage);
+                      }}
                       rowsPerPage={rowsPerPage}
                       onRowsPerPageChange={(event) => {
+                        if (inventoryBusy) return;
                         setRowsPerPage(parseInt(event.target.value, 10));
                         setPage(0);
                       }}
                       rowsPerPageOptions={[10, 25, 50, 100, 250]}
+                      backIconButtonProps={{ disabled: inventoryBusy }}
+                      nextIconButtonProps={{ disabled: inventoryBusy }}
+                      SelectProps={{ disabled: inventoryBusy }}
                       sx={{ mt: 2 }}
                     />
                   </>
@@ -1888,6 +2239,7 @@ const InventoryPage = () => {
             </Card>
           </Grid>
         </Grid>
+        </Box>
       </Container>
 
       <Dialog
@@ -1896,7 +2248,11 @@ const InventoryPage = () => {
         fullWidth
         maxWidth="lg"
       >
-        <DialogTitle>Quick add inventory item</DialogTitle>
+        <DialogTitle>
+          {viewMode === 'org'
+            ? `Add org inventory item · ${selectedOrgName}`
+            : 'Quick add inventory item'}
+        </DialogTitle>
         <DialogContent dividers onKeyDown={handleAddKeyDown}>
           <Stack spacing={2} sx={{ mt: 1 }}>
             {catalogError && <Alert severity="error">{catalogError}</Alert>}
@@ -2075,7 +2431,7 @@ const InventoryPage = () => {
                       setCatalogRowsPerPage(parseInt(event.target.value, 10));
                       setCatalogPage(0);
                     }}
-                    rowsPerPageOptions={[10, 25, 50]}
+                    rowsPerPageOptions={[25, 50]}
                   />
                 </Box>
               </Grid>

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -552,7 +552,7 @@ const InventoryPage = () => {
     }
   }, [
     user,
-    viewMode,
+    isOrgMode,
     selectedOrgId,
     filters.categoryId,
     filters.locationId,
@@ -1296,11 +1296,10 @@ const InventoryPage = () => {
     focusController,
     inlineDrafts,
     inlineSaving,
-    inventoryService,
-    isOrgMode,
     items,
     locationNameById,
     selectedOrgId,
+    viewMode,
   ]);
 
   const handleInlineSaveAndAdvance = useCallback(async (item: InventoryRecord) => {

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -275,6 +275,8 @@ const InventoryPage = () => {
         const nextLocation =
           changes.locationId === undefined
             ? prev[itemId]?.locationId ?? ''
+            : changes.locationId === ''
+            ? ''
             : Number.isNaN(Number(changes.locationId))
             ? ''
             : (Number(changes.locationId) as number);
@@ -1217,17 +1219,18 @@ const InventoryPage = () => {
 
     if (
       !Number.isInteger(parsedLocationId) ||
+      parsedLocationId <= 0 ||
       !Number.isFinite(parsedQuantity) ||
       parsedQuantity < MIN_INVENTORY_QUANTITY
     ) {
       setInlineError((prev) => ({
         ...prev,
         [item.id]:
-          !Number.isInteger(parsedLocationId)
+          !Number.isInteger(parsedLocationId) || parsedLocationId <= 0
             ? 'Select a valid location'
             : 'Quantity must be at least 0.01',
       }));
-      if (!Number.isInteger(parsedLocationId)) {
+      if (!Number.isInteger(parsedLocationId) || parsedLocationId <= 0) {
         focusController.focus(item.id.toString(), 'location');
       } else {
         focusController.focus(item.id.toString(), 'quantity');

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -62,6 +62,7 @@ type ActionMode = 'edit' | 'split' | 'share' | 'delete' | null;
 
 const GAME_ID = 1;
 const EDITOR_MODE_QUANTITY_MAX = 100000;
+const MIN_INVENTORY_QUANTITY = 0.01;
 const ORG_ACCENT = '#f2a255';
 const VIEW_MODE_STORAGE_KEY = 'inventory:viewMode';
 const ORG_ID_STORAGE_KEY = 'inventory:selectedOrgId';
@@ -264,10 +265,7 @@ const InventoryPage = () => {
           [rowKey]: initialInput ?? prev[rowKey] ?? '',
         }));
       }
-      const parsedId = Number(rowKey);
-      if (!Number.isNaN(parsedId)) {
-        setInlineError((prev) => ({ ...prev, [parsedId]: null }));
-      }
+      setInlineError((prev) => ({ ...prev, [rowKey]: null }));
     },
     [],
   );
@@ -980,8 +978,8 @@ const InventoryPage = () => {
     if (!Number.isInteger(parsedLocationId) || parsedLocationId <= 0) {
       errors.location = 'Select a valid location';
     }
-    if (!Number.isInteger(parsedQuantity) || parsedQuantity <= 0) {
-      errors.quantity = 'Quantity must be an integer greater than 0';
+    if (!Number.isFinite(parsedQuantity) || parsedQuantity < MIN_INVENTORY_QUANTITY) {
+      errors.quantity = 'Quantity must be at least 0.01';
     }
 
     if (errors.item || errors.location || errors.quantity) {
@@ -1217,13 +1215,17 @@ const InventoryPage = () => {
       draft.locationId === '' ? NaN : Number(draft.locationId);
     const parsedQuantity = Number(draft.quantity);
 
-    if (!Number.isInteger(parsedLocationId) || !Number.isInteger(parsedQuantity) || parsedQuantity <= 0) {
+    if (
+      !Number.isInteger(parsedLocationId) ||
+      !Number.isFinite(parsedQuantity) ||
+      parsedQuantity < MIN_INVENTORY_QUANTITY
+    ) {
       setInlineError((prev) => ({
         ...prev,
         [item.id]:
           !Number.isInteger(parsedLocationId)
             ? 'Select a valid location'
-            : 'Quantity must be an integer greater than 0',
+            : 'Quantity must be at least 0.01',
       }));
       if (!Number.isInteger(parsedLocationId)) {
         focusController.focus(item.id.toString(), 'location');
@@ -2141,10 +2143,10 @@ const InventoryPage = () => {
                           ...prev,
                           quantity: nextQuantity,
                         }));
-                        if (!Number.isInteger(numeric) || numeric <= 0) {
+                        if (!Number.isFinite(numeric) || numeric < MIN_INVENTORY_QUANTITY) {
                           setNewRowErrors((prev) => ({
                             ...prev,
-                            quantity: 'Quantity must be an integer greater than 0',
+                            quantity: 'Quantity must be at least 0.01',
                             api: null,
                           }));
                         } else {

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -605,8 +605,8 @@ const InventoryPage = () => {
       setCatalogError('Select a location.');
       return;
     }
-    if (newItemQuantity <= 0) {
-      setCatalogError('Quantity must be greater than 0.');
+    if (newItemQuantity < MIN_INVENTORY_QUANTITY) {
+      setCatalogError('Quantity must be at least 0.01.');
       return;
     }
 
@@ -689,11 +689,27 @@ const InventoryPage = () => {
         setCatalogError('You do not have permission to add items to this organization.');
       } else if (status === 409 && viewMode === 'org' && selectedOrgId) {
         const numericLocationId = Number(destinationSelection.locationId);
-        const existing = items.find(
+        let existing = items.find(
           (item) =>
             item.uexItemId === selectedCatalogItem?.uexId &&
             item.locationId === numericLocationId,
         );
+        if (!existing && selectedCatalogItem) {
+          try {
+            const lookupResult = await inventoryService.getOrgInventory(selectedOrgId, {
+              gameId: GAME_ID,
+              uexItemId: selectedCatalogItem.uexId,
+              locationId: numericLocationId,
+              limit: 1,
+              offset: 0,
+            });
+            if (lookupResult.items.length > 0) {
+              existing = lookupResult.items[0];
+            }
+          } catch (lookupErr) {
+            console.error('Error looking up conflicting org inventory item', lookupErr);
+          }
+        }
         if (existing) {
           const shouldMerge = window.confirm(
             'This org already has this item at the selected location. Merge quantities?',
@@ -797,10 +813,15 @@ const InventoryPage = () => {
   }, [addDialogOpen, fetchCatalog]);
 
   useEffect(() => {
-    if (addDialogOpen && viewMode === 'org' && !canManageOrgInventory) {
+    if (
+      addDialogOpen &&
+      viewMode === 'org' &&
+      !orgPermissionsLoading &&
+      !canManageOrgInventory
+    ) {
       setAddDialogOpen(false);
     }
-  }, [addDialogOpen, viewMode, canManageOrgInventory]);
+  }, [addDialogOpen, viewMode, orgPermissionsLoading, canManageOrgInventory]);
 
   useEffect(() => {
     if (!addDialogOpen) return;

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -68,6 +68,13 @@ const VIEW_MODE_STORAGE_KEY = 'inventory:viewMode';
 const ORG_ID_STORAGE_KEY = 'inventory:selectedOrgId';
 const DENSITY_STORAGE_KEY = 'inventory:density';
 
+const normalizeDraftLocationId = (locationId: number | ''): number | '' =>
+  typeof locationId === 'string'
+    ? locationId === ''
+      ? ''
+      : Number(locationId)
+    : locationId;
+
 const readStoredViewMode = (): 'personal' | 'org' => {
   if (typeof window === 'undefined') return 'personal';
   const stored = window.sessionStorage.getItem(VIEW_MODE_STORAGE_KEY);
@@ -1783,8 +1790,7 @@ const InventoryPage = () => {
       quantity: Number(item.quantity) || 0,
     };
     const originalLocationId = Number(item.locationId) || '';
-    const draftLocationId =
-      typeof draft.locationId === 'string' ? Number(draft.locationId) : draft.locationId;
+    const draftLocationId = normalizeDraftLocationId(draft.locationId);
     const originalQuantity = Number(item.quantity) || 0;
     const draftQuantityNumber = Number(draft.quantity);
     const isDirty =

--- a/frontend/src/services/permissions.service.ts
+++ b/frontend/src/services/permissions.service.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+
+export const OrgPermission = {
+  CAN_VIEW_ORG_INVENTORY: 'can_view_org_inventory',
+  CAN_EDIT_ORG_INVENTORY: 'can_edit_org_inventory',
+  CAN_ADMIN_ORG_INVENTORY: 'can_admin_org_inventory',
+  CAN_VIEW_MEMBER_SHARED_ITEMS: 'can_view_member_shared_items',
+} as const;
+
+export type OrgPermission = (typeof OrgPermission)[keyof typeof OrgPermission];
+
+const getAuthHeader = () => {
+  const token = localStorage.getItem('access_token');
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+};
+
+export const permissionsService = {
+  async getUserPermissions(
+    userId: number,
+    organizationId: number,
+  ): Promise<OrgPermission[]> {
+    const response = await axios.get(
+      `${API_URL}/permissions/user/${userId}/organization/${organizationId}`,
+      {
+        headers: getAuthHeader(),
+      },
+    );
+    const permissions = response.data?.permissions;
+    return Array.isArray(permissions) ? permissions : [];
+  },
+};


### PR DESCRIPTION
## Summary
- add the org inventory catalog add flow in the inventory UI with org-mode permission gating
- handle duplicate org item conflicts with backend 409 detection and frontend merge/update recovery
- include the supporting inventory filter and inline-row updates used by this cleaned issue 55 branch

## Validation
- pnpm --filter frontend typecheck
- pnpm --filter backend test -- org-inventory.service.spec.ts

## Notes
- this PR is the cleaned issue 55 branch and intentionally excludes the out-of-scope UEX orbit/location sync work that had been mixed into the older branch

Closes #55