### PR TITLE
fix: remove debug artifacts and fix password reset token log exposure

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -34,51 +34,49 @@ async function bootstrap() {
   // Global Exception Filter for standardized error responses
   app.useGlobalFilters(new HttpExceptionFilter());
 
-  // Swagger/OpenAPI Documentation Setup
-  const config = new DocumentBuilder()
-    .setTitle('Station API')
-    .setDescription(
-      'API documentation for Station - Gaming guild and organization management portal',
-    )
-    .setVersion('1.0')
-    .addTag('auth', 'Authentication endpoints')
-    .addTag('users', 'User management endpoints')
-    .addTag('organizations', 'Organization management endpoints')
-    .addTag('roles', 'Role management endpoints')
-    .addTag(
-      'user-organization-roles',
-      'User-Organization-Role assignment endpoints',
-    )
-    .addTag('permissions', 'Permission aggregation endpoints')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'JWT',
-        description: 'Enter JWT token',
-        in: 'header',
-      },
-      'access-token',
-    )
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        name: 'Refresh Token',
-        description: 'Enter refresh token',
-        in: 'header',
-      },
-      'refresh-token',
-    )
-    .build();
+  // Swagger/OpenAPI Documentation — development only
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('Station API')
+      .setDescription(
+        'API documentation for Station - Gaming guild and organization management portal',
+      )
+      .setVersion('1.0')
+      .addTag('auth', 'Authentication endpoints')
+      .addTag('users', 'User management endpoints')
+      .addTag('organizations', 'Organization management endpoints')
+      .addTag('roles', 'Role management endpoints')
+      .addTag(
+        'user-organization-roles',
+        'User-Organization-Role assignment endpoints',
+      )
+      .addTag('permissions', 'Permission aggregation endpoints')
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          name: 'JWT',
+          description: 'Enter JWT token',
+          in: 'header',
+        },
+        'access-token',
+      )
+      .addBearerAuth(
+        {
+          type: 'http',
+          scheme: 'bearer',
+          name: 'Refresh Token',
+          description: 'Enter refresh token',
+          in: 'header',
+        },
+        'refresh-token',
+      )
+      .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document, {
-    swaggerOptions: {
-      persistAuthorization: true,
-    },
-  });
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api/docs', app, document);
+  }
 
   // Log application startup information
   await app.listen(port);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -84,10 +84,12 @@ async function bootstrap() {
     `🚀 Application '${appName}' is running on: http://localhost:${port}`,
     'Bootstrap',
   );
-  Logger.log(
-    `📚 Swagger documentation available at: http://localhost:${port}/api/docs`,
-    'Bootstrap',
-  );
+  if (process.env.NODE_ENV !== 'production') {
+    Logger.log(
+      `📚 Swagger documentation available at: http://localhost:${port}/api/docs`,
+      'Bootstrap',
+    );
+  }
 }
 
 bootstrap();

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Post,
-  UseGuards,
-  Request,
-  Body,
-  Get,
-} from '@nestjs/common';
+import { Controller, Post, UseGuards, Request, Body } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -19,7 +12,6 @@ import { JwtAuthGuard } from './jwt-auth.guard';
 import { RefreshTokenAuthGuard } from './refresh-token-auth.guard';
 import { UserDto } from '../users/dto/user.dto';
 import { Request as ExpressRequest } from 'express';
-import * as bcrypt from 'bcrypt';
 import {
   ChangePasswordDto,
   ForgotPasswordDto,
@@ -122,23 +114,5 @@ export class AuthController {
       currentPassword,
       newPassword,
     );
-  }
-
-  @Get('test')
-  async testBCrypt() {
-    (async () => {
-      const plainPassword = 'securePassword123';
-      const saltRounds = 10;
-
-      // Simulate Registration
-      const hashedPassword = await bcrypt.hash(plainPassword, saltRounds);
-      console.log('Plain password:', plainPassword);
-      console.log('Hashed password:', hashedPassword);
-
-      // Simulate Login
-      const isMatch = await bcrypt.compare(plainPassword, hashedPassword);
-      console.log('Passwords match:', isMatch);
-      return isMatch;
-    })();
   }
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -174,13 +174,7 @@ export class AuthService {
     });
 
     // TODO: Send email with reset link
-    // For now, just log the token (in production, send via email service)
-    this.logger.log(
-      `Password reset token for ${email}: ${token} (expires at ${expiresAt})`,
-    );
-    this.logger.log(
-      `Reset link would be: ${this.configService.get('FRONTEND_URL') || 'http://localhost:5173'}/reset-password?token=${token}`,
-    );
+    this.logger.log(`Password reset requested for user ID: ${user.id}`);
 
     return successMessage;
   }


### PR DESCRIPTION
## Summary
- Deletes the `GET /auth/test` debug endpoint and its `bcrypt` import from `AuthController`
- Replaces the two logger calls in `requestPasswordReset()` that leaked the raw token and reset URL with a single neutral log: `Password reset requested for user ID: X`
- Gates Swagger UI (`/api/docs`) behind `NODE_ENV !== 'production'`
- Removes `persistAuthorization: true` from Swagger options

## Test plan
- [ ] `GET /auth/test` returns 404
- [ ] `POST /auth/forgot-password` logs only `Password reset requested for user ID: X` — no token, no URL
- [ ] Swagger UI loads at `/api/docs` in development (`NODE_ENV=development`)
- [ ] Swagger UI is not served when `NODE_ENV=production`

Closes #99