### PR TITLE
feat: add Terraform Linode foundation config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-error.log*
 
 # Environment variables
 .env
+.env.production
 
 # Logs
 logs/
@@ -56,3 +57,9 @@ out/
 .DS_Store
 
 .turbo/
+
+# Terraform
+infra/terraform/.terraform/
+infra/terraform/terraform.tfvars
+infra/terraform/*.tfstate
+infra/terraform/*.tfstate.backup

--- a/infra/README.md
+++ b/infra/README.md
@@ -34,11 +34,11 @@ Review `terraform plan` before every apply. The existing VPS must be imported ra
 ### Variables
 
 - `linode_token`: Linode API token
-- `vps_ip`: public IPv4 of the VPS
+- `vps_ip`: optional fallback public IPv4 of the VPS if the imported instance IP is not yet available
 - `vps_label`: Linode label of the imported VPS
 - `vps_region`: Linode region slug of the imported VPS
 - `vps_type`: Linode plan type of the imported VPS
 - `vps_image`: base image recorded for the imported VPS
-- `ssh_public_key`: deploy SSH public key
+- `ssh_public_key`: optional deploy SSH public key when Terraform should manage authorized keys
 
 Keep real values in `infra/terraform/terraform.tfvars`, which is gitignored.

--- a/infra/README.md
+++ b/infra/README.md
@@ -34,9 +34,11 @@ Review `terraform plan` before every apply. The existing VPS must be imported ra
 ### Variables
 
 - `linode_token`: Linode API token
-- `linode_instance_id`: existing Linode instance ID to import
-- `linode_domain_id`: existing Linode domain ID to import
 - `vps_ip`: public IPv4 of the VPS
+- `vps_label`: Linode label of the imported VPS
+- `vps_region`: Linode region slug of the imported VPS
+- `vps_type`: Linode plan type of the imported VPS
+- `vps_image`: base image recorded for the imported VPS
 - `ssh_public_key`: deploy SSH public key
 
 Keep real values in `infra/terraform/terraform.tfvars`, which is gitignored.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,42 @@
+# Infrastructure
+
+This directory holds the infrastructure-as-code and VPS provisioning assets for Station.
+
+## Terraform Setup
+
+Issue `#106` establishes the Linode foundation as code. The Terraform configuration manages:
+
+- the existing Linode VPS instance through `terraform import`
+- the Linode firewall allowing only TCP ports `22`, `80`, and `443`
+- the DNS records for `api.drdnt.org`, `station.drdnt.org`, and `bot.drdnt.org`
+
+### Files
+
+- `terraform/main.tf`: provider, instance, and firewall configuration
+- `terraform/dns.tf`: Linode domain and A records
+- `terraform/variables.tf`: required input variables
+- `terraform/outputs.tf`: useful outputs for the VPS IP and FQDNs
+- `terraform/terraform.tfvars.example`: example input values
+
+### Workflow
+
+```bash
+cd infra/terraform
+terraform init
+terraform import linode_instance.vps <linode-instance-id>
+terraform import linode_domain.drdnt_org <linode-domain-id>
+terraform plan
+terraform apply
+```
+
+Review `terraform plan` before every apply. The existing VPS must be imported rather than recreated.
+
+### Variables
+
+- `linode_token`: Linode API token
+- `linode_instance_id`: existing Linode instance ID to import
+- `linode_domain_id`: existing Linode domain ID to import
+- `vps_ip`: public IPv4 of the VPS
+- `ssh_public_key`: deploy SSH public key
+
+Keep real values in `infra/terraform/terraform.tfvars`, which is gitignored.

--- a/infra/README.md
+++ b/infra/README.md
@@ -39,6 +39,6 @@ Review `terraform plan` before every apply. The existing VPS must be imported ra
 - `vps_region`: Linode region slug of the imported VPS
 - `vps_type`: Linode plan type of the imported VPS
 - `vps_image`: base image recorded for the imported VPS
-- `ssh_public_key`: optional deploy SSH public key when Terraform should manage authorized keys
+- `ssh_public_key`: optional deploy SSH public key for initial instance configuration; authorized keys are not continuously managed after import
 
 Keep real values in `infra/terraform/terraform.tfvars`, which is gitignored.

--- a/infra/package.json
+++ b/infra/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "scripts": {
     "build": "node -e \"process.exit(0)\"",
-    "test": "node --test tests/**/*.test.mjs"
+    "test": "node --test tests"
   }
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "infra",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node -e \"process.exit(0)\"",
+    "test": "node --test tests/**/*.test.mjs"
+  }
+}

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,2 +1,4 @@
-# Run `terraform init` in this directory to generate and refresh provider locks.
-# Terraform will replace this placeholder with the real provider selections and hashes.
+# Temporary stub only: this file does not yet contain any provider selections or hashes.
+# Run `terraform init` in this directory and commit the generated `.terraform.lock.hcl`
+# to lock provider versions reproducibly before relying on this configuration in CI/CD.
+# Until that real lockfile is committed, do not use `terraform init -lockfile=readonly`.

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,2 @@
+# Run `terraform init` in this directory to generate and refresh provider locks.
+# Terraform will replace this placeholder with the real provider selections and hashes.

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -19,6 +19,15 @@ resource "linode_domain_record" "api" {
   record_type = "A"
   target      = local.vps_ipv4
   ttl_sec     = 300
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  precondition {
+    condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
+    error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+  }
 }
 
 resource "linode_domain_record" "station" {
@@ -27,6 +36,15 @@ resource "linode_domain_record" "station" {
   record_type = "A"
   target      = local.vps_ipv4
   ttl_sec     = 300
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  precondition {
+    condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
+    error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+  }
 }
 
 resource "linode_domain_record" "bot" {
@@ -35,4 +53,13 @@ resource "linode_domain_record" "bot" {
   record_type = "A"
   target      = local.vps_ipv4
   ttl_sec     = 300
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  precondition {
+    condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
+    error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+  }
 }

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -22,11 +22,10 @@ resource "linode_domain_record" "api" {
 
   lifecycle {
     prevent_destroy = true
-  }
-
-  precondition {
-    condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
-    error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+    precondition {
+      condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
+      error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+    }
   }
 }
 
@@ -39,11 +38,10 @@ resource "linode_domain_record" "station" {
 
   lifecycle {
     prevent_destroy = true
-  }
-
-  precondition {
-    condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
-    error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+    precondition {
+      condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
+      error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+    }
   }
 }
 
@@ -56,10 +54,9 @@ resource "linode_domain_record" "bot" {
 
   lifecycle {
     prevent_destroy = true
-  }
-
-  precondition {
-    condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
-    error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+    precondition {
+      condition     = local.vps_ipv4 != null && trim(local.vps_ipv4) != ""
+      error_message = "Provide vps_ip until the imported VPS exposes a non-empty public IPv4 address, otherwise DNS records cannot be created safely."
+    }
   }
 }

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -1,5 +1,5 @@
 locals {
-  vps_ipv4 = var.vps_ip != null ? var.vps_ip : linode_instance.vps.ip_address
+  vps_ipv4 = linode_instance.vps.ip_address != null && linode_instance.vps.ip_address != "" ? linode_instance.vps.ip_address : var.vps_ip
 }
 
 resource "linode_domain" "drdnt_org" {

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -1,0 +1,30 @@
+resource "linode_domain" "drdnt_org" {
+  domain      = "drdnt.org"
+  type        = "master"
+  soa_email   = "admin@drdnt.org"
+  description = "Station DNS zone"
+}
+
+resource "linode_domain_record" "api" {
+  domain_id   = linode_domain.drdnt_org.id
+  name        = "api"
+  record_type = "A"
+  target      = var.vps_ip
+  ttl_sec     = 300
+}
+
+resource "linode_domain_record" "station" {
+  domain_id   = linode_domain.drdnt_org.id
+  name        = "station"
+  record_type = "A"
+  target      = var.vps_ip
+  ttl_sec     = 300
+}
+
+resource "linode_domain_record" "bot" {
+  domain_id   = linode_domain.drdnt_org.id
+  name        = "bot"
+  record_type = "A"
+  target      = var.vps_ip
+  ttl_sec     = 300
+}

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -1,15 +1,23 @@
+locals {
+  vps_ipv4 = var.vps_ip != null ? var.vps_ip : linode_instance.vps.ip_address
+}
+
 resource "linode_domain" "drdnt_org" {
   domain      = "drdnt.org"
   type        = "master"
   soa_email   = "admin@drdnt.org"
   description = "Station DNS zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "linode_domain_record" "api" {
   domain_id   = linode_domain.drdnt_org.id
   name        = "api"
   record_type = "A"
-  target      = var.vps_ip
+  target      = local.vps_ipv4
   ttl_sec     = 300
 }
 
@@ -17,7 +25,7 @@ resource "linode_domain_record" "station" {
   domain_id   = linode_domain.drdnt_org.id
   name        = "station"
   record_type = "A"
-  target      = var.vps_ip
+  target      = local.vps_ipv4
   ttl_sec     = 300
 }
 
@@ -25,6 +33,6 @@ resource "linode_domain_record" "bot" {
   domain_id   = linode_domain.drdnt_org.id
   name        = "bot"
   record_type = "A"
-  target      = var.vps_ip
+  target      = local.vps_ipv4
   ttl_sec     = 300
 }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = "~> 2.34"
+    }
+  }
+}
+
+provider "linode" {
+  token = var.linode_token
+}
+
+resource "linode_instance" "vps" {
+  label      = "station-vps"
+  type       = "g6-standard-1"
+  region     = "us-east"
+  image      = "linode/ubuntu24.04"
+  authorized_keys = [var.ssh_public_key]
+}
+
+resource "linode_firewall" "station" {
+  label = "station-vps-firewall"
+
+  inbound {
+    label    = "allow-ssh"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "22"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound {
+    label    = "allow-http"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "80"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound {
+    label    = "allow-https"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "443"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound_policy  = "DROP"
+  outbound_policy = "ACCEPT"
+
+  linodes = [linode_instance.vps.id]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -18,7 +18,7 @@ resource "linode_instance" "vps" {
   type            = var.vps_type
   region          = var.vps_region
   image           = var.vps_image
-  authorized_keys = [var.ssh_public_key]
+  authorized_keys = var.ssh_public_key == null ? null : [var.ssh_public_key]
 
   lifecycle {
     prevent_destroy = true
@@ -65,4 +65,8 @@ resource "linode_firewall" "station" {
   outbound_policy = "ACCEPT"
 
   linodes = [linode_instance.vps.id]
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -14,11 +14,21 @@ provider "linode" {
 }
 
 resource "linode_instance" "vps" {
-  label      = "station-vps"
-  type       = "g6-standard-1"
-  region     = "us-east"
-  image      = "linode/ubuntu24.04"
+  label           = var.vps_label
+  type            = var.vps_type
+  region          = var.vps_region
+  image           = var.vps_image
   authorized_keys = [var.ssh_public_key]
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      type,
+      region,
+      image,
+      authorized_keys,
+    ]
+  }
 }
 
 resource "linode_firewall" "station" {

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,6 +1,6 @@
 output "vps_ip" {
   description = "Public IPv4 address for the Station VPS."
-  value       = var.vps_ip
+  value       = local.vps_ipv4
 }
 
 output "api_fqdn" {

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "vps_ip" {
+  description = "Public IPv4 address for the Station VPS."
+  value       = var.vps_ip
+}
+
+output "api_fqdn" {
+  description = "API hostname."
+  value       = "api.${linode_domain.drdnt_org.domain}"
+}
+
+output "station_fqdn" {
+  description = "Frontend hostname."
+  value       = "station.${linode_domain.drdnt_org.domain}"
+}
+
+output "bot_fqdn" {
+  description = "Bot hostname."
+  value       = "bot.${linode_domain.drdnt_org.domain}"
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,5 +1,7 @@
 linode_token       = "replace-with-your-linode-api-token"
-linode_instance_id = 12345678
-linode_domain_id   = 87654321
 vps_ip             = "203.0.113.10"
+vps_label          = "station-vps"
+vps_region         = "us-east"
+vps_type           = "g6-standard-1"
+vps_image          = "linode/ubuntu24.04"
 ssh_public_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... deploy@example"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,5 @@
+linode_token       = "replace-with-your-linode-api-token"
+linode_instance_id = 12345678
+linode_domain_id   = 87654321
+vps_ip             = "203.0.113.10"
+ssh_public_key     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... deploy@example"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -5,10 +5,15 @@ variable "linode_token" {
 }
 
 variable "vps_ip" {
-  description = "Optional fallback public IPv4 address of the Station VPS when the imported instance IP is not yet available."
+  description = "Fallback public IPv4 address of the Station VPS. Provide this until the imported instance IP is available so DNS records always have a valid target."
   type        = string
   nullable    = true
   default     = null
+
+  validation {
+    condition     = var.vps_ip == null || trim(var.vps_ip) != ""
+    error_message = "vps_ip must be omitted or set to a non-empty IPv4 string."
+  }
 }
 
 variable "vps_label" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -32,7 +32,7 @@ variable "vps_image" {
 }
 
 variable "ssh_public_key" {
-  description = "SSH public key content for the deploy user. Optional for imported VPS workflows; set this only when Terraform should manage authorized keys."
+  description = "SSH public key content for the deploy user. Optional for imported VPS workflows; if set, this is intended only for initial/create-time authorized_keys configuration and is not reconciled by Terraform after import or later changes."
   type        = string
   nullable    = true
   default     = null

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -5,8 +5,10 @@ variable "linode_token" {
 }
 
 variable "vps_ip" {
-  description = "Public IPv4 address of the Station VPS."
+  description = "Optional fallback public IPv4 address of the Station VPS when the imported instance IP is not yet available."
   type        = string
+  nullable    = true
+  default     = null
 }
 
 variable "vps_label" {
@@ -30,6 +32,8 @@ variable "vps_image" {
 }
 
 variable "ssh_public_key" {
-  description = "SSH public key content for the deploy user."
+  description = "SSH public key content for the deploy user. Optional for imported VPS workflows; set this only when Terraform should manage authorized keys."
   type        = string
+  nullable    = true
+  default     = null
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -11,8 +11,13 @@ variable "vps_ip" {
   default     = null
 
   validation {
-    condition     = var.vps_ip == null || trim(var.vps_ip) != ""
-    error_message = "vps_ip must be omitted or set to a non-empty IPv4 string."
+    condition = (
+      var.vps_ip == null || (
+        trim(var.vps_ip) != "" &&
+        can(cidrhost("${trim(var.vps_ip)}/32", 0))
+      )
+    )
+    error_message = "vps_ip must be omitted or set to a valid IPv4 address."
   }
 }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -4,18 +4,28 @@ variable "linode_token" {
   sensitive   = true
 }
 
-variable "linode_instance_id" {
-  description = "Existing Linode instance ID to import."
-  type        = number
-}
-
-variable "linode_domain_id" {
-  description = "Existing Linode domain ID to import."
-  type        = number
-}
-
 variable "vps_ip" {
   description = "Public IPv4 address of the Station VPS."
+  type        = string
+}
+
+variable "vps_label" {
+  description = "Linode label of the imported VPS."
+  type        = string
+}
+
+variable "vps_region" {
+  description = "Linode region slug of the imported VPS."
+  type        = string
+}
+
+variable "vps_type" {
+  description = "Linode plan type of the imported VPS."
+  type        = string
+}
+
+variable "vps_image" {
+  description = "Base image recorded for the imported VPS."
   type        = string
 }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,25 @@
+variable "linode_token" {
+  description = "Linode API personal access token."
+  type        = string
+  sensitive   = true
+}
+
+variable "linode_instance_id" {
+  description = "Existing Linode instance ID to import."
+  type        = number
+}
+
+variable "linode_domain_id" {
+  description = "Existing Linode domain ID to import."
+  type        = number
+}
+
+variable "vps_ip" {
+  description = "Public IPv4 address of the Station VPS."
+  type        = string
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key content for the deploy user."
+  type        = string
+}

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -68,11 +68,13 @@ test('terraform configuration files exist and define the Linode foundation', () 
 
 test('gitignore excludes terraform local state and secrets', () => {
   const gitignore = readInfraFile('../.gitignore');
+  const lockfile = readInfraFile('../pnpm-lock.yaml');
 
   assert.match(gitignore, /infra\/terraform\/\.terraform\//);
   assert.match(gitignore, /infra\/terraform\/terraform\.tfvars/);
   assert.match(gitignore, /infra\/terraform\/\*\.tfstate/);
   assert.match(gitignore, /infra\/terraform\/\*\.tfstate\.backup/);
+  assert.match(lockfile, /\n  infra: \{\}/);
 });
 
 test('infra README documents terraform import and apply workflow', () => {

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const infraRoot = path.resolve(__dirname, '..');
+
+const readInfraFile = (relativePath) =>
+  readFileSync(path.join(infraRoot, relativePath), 'utf8');
+
+test('terraform configuration files exist and define the Linode foundation', () => {
+  const mainTf = readInfraFile('terraform/main.tf');
+  const dnsTf = readInfraFile('terraform/dns.tf');
+  const variablesTf = readInfraFile('terraform/variables.tf');
+  const outputsTf = readInfraFile('terraform/outputs.tf');
+  const tfvars = readInfraFile('terraform/terraform.tfvars.example');
+  const lockfile = readInfraFile('terraform/.terraform.lock.hcl');
+
+  assert.match(mainTf, /required_providers/);
+  assert.match(mainTf, /source\s*=\s*"linode\/linode"/);
+  assert.match(mainTf, /resource "linode_instance" "vps"/);
+  assert.match(mainTf, /resource "linode_firewall" "station"/);
+  assert.match(mainTf, /ports\s*=\s*"22"/);
+  assert.match(mainTf, /ports\s*=\s*"80"/);
+  assert.match(mainTf, /ports\s*=\s*"443"/);
+
+  assert.match(dnsTf, /resource "linode_domain" "drdnt_org"/);
+  assert.match(dnsTf, /resource "linode_domain_record" "api"/);
+  assert.match(dnsTf, /resource "linode_domain_record" "station"/);
+  assert.match(dnsTf, /resource "linode_domain_record" "bot"/);
+
+  assert.match(variablesTf, /variable "linode_token"/);
+  assert.match(variablesTf, /variable "linode_instance_id"/);
+  assert.match(variablesTf, /variable "linode_domain_id"/);
+  assert.match(variablesTf, /variable "vps_ip"/);
+  assert.match(variablesTf, /variable "ssh_public_key"/);
+
+  assert.match(outputsTf, /output "vps_ip"/);
+  assert.match(outputsTf, /output "api_fqdn"/);
+  assert.match(outputsTf, /output "station_fqdn"/);
+  assert.match(outputsTf, /output "bot_fqdn"/);
+
+  assert.match(tfvars, /linode_token/);
+  assert.match(tfvars, /linode_instance_id/);
+  assert.match(tfvars, /linode_domain_id/);
+  assert.match(tfvars, /vps_ip/);
+  assert.match(tfvars, /ssh_public_key/);
+
+  assert.match(lockfile, /terraform init/);
+  assert.match(lockfile, /provider locks/);
+});
+
+test('gitignore excludes terraform local state and secrets', () => {
+  const gitignore = readInfraFile('../.gitignore');
+
+  assert.match(gitignore, /infra\/terraform\/\.terraform\//);
+  assert.match(gitignore, /infra\/terraform\/terraform\.tfvars/);
+  assert.match(gitignore, /infra\/terraform\/\*\.tfstate/);
+  assert.match(gitignore, /infra\/terraform\/\*\.tfstate\.backup/);
+});
+
+test('infra README documents terraform import and apply workflow', () => {
+  const readme = readInfraFile('README.md');
+
+  assert.match(readme, /Terraform Setup/);
+  assert.match(readme, /terraform init/);
+  assert.match(readme, /terraform import linode_instance\.vps/);
+  assert.match(readme, /terraform import linode_domain\.drdnt_org/);
+  assert.match(readme, /terraform plan/);
+  assert.match(readme, /terraform apply/);
+});

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -74,7 +74,7 @@ test('gitignore excludes terraform local state and secrets', () => {
   assert.match(gitignore, /infra\/terraform\/terraform\.tfvars/);
   assert.match(gitignore, /infra\/terraform\/\*\.tfstate/);
   assert.match(gitignore, /infra\/terraform\/\*\.tfstate\.backup/);
-  assert.match(lockfile, /\n  infra: \{\}/);
+  assert.match(lockfile, /(?:^|\n)importers:\s*(?:\n(?!\S).*)*\n\s{2,}infra:\s*(?:\{\}|$)/);
 });
 
 test('infra README documents terraform import and apply workflow', () => {
@@ -86,6 +86,8 @@ test('infra README documents terraform import and apply workflow', () => {
   assert.match(readme, /terraform import linode_domain\.drdnt_org/);
   assert.match(readme, /terraform plan/);
   assert.match(readme, /terraform apply/);
-  assert.doesNotMatch(readme, /linode_instance_id/);
-  assert.doesNotMatch(readme, /linode_domain_id/);
+  assert.match(
+    readme,
+    /ssh_public_key`: optional deploy SSH public key for initial instance configuration; authorized keys are not continuously managed after import/,
+  );
 });

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -70,12 +70,16 @@ test('terraform configuration files exist and define the Linode foundation', () 
 
 test('gitignore excludes terraform local state and secrets', () => {
   const gitignore = readInfraFile('../.gitignore');
-  const lockfile = readInfraFile('../pnpm-lock.yaml');
 
   assert.match(gitignore, /infra\/terraform\/\.terraform\//);
   assert.match(gitignore, /infra\/terraform\/terraform\.tfvars/);
   assert.match(gitignore, /infra\/terraform\/\*\.tfstate/);
   assert.match(gitignore, /infra\/terraform\/\*\.tfstate\.backup/);
+});
+
+test('pnpm lockfile includes the infra importer', () => {
+  const lockfile = readInfraFile('../pnpm-lock.yaml');
+
   assert.match(lockfile, /(?:^|\n)importers:\s*(?:\n(?!\S).*)*\n\s{2,}infra:\s*(?:\{\}|$)/);
 });
 

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -32,9 +32,11 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(dnsTf, /resource "linode_domain_record" "bot"/);
 
   assert.match(variablesTf, /variable "linode_token"/);
-  assert.match(variablesTf, /variable "linode_instance_id"/);
-  assert.match(variablesTf, /variable "linode_domain_id"/);
   assert.match(variablesTf, /variable "vps_ip"/);
+  assert.match(variablesTf, /variable "vps_label"/);
+  assert.match(variablesTf, /variable "vps_region"/);
+  assert.match(variablesTf, /variable "vps_type"/);
+  assert.match(variablesTf, /variable "vps_image"/);
   assert.match(variablesTf, /variable "ssh_public_key"/);
 
   assert.match(outputsTf, /output "vps_ip"/);
@@ -43,13 +45,19 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(outputsTf, /output "bot_fqdn"/);
 
   assert.match(tfvars, /linode_token/);
-  assert.match(tfvars, /linode_instance_id/);
-  assert.match(tfvars, /linode_domain_id/);
   assert.match(tfvars, /vps_ip/);
+  assert.match(tfvars, /vps_label/);
+  assert.match(tfvars, /vps_region/);
+  assert.match(tfvars, /vps_type/);
+  assert.match(tfvars, /vps_image/);
   assert.match(tfvars, /ssh_public_key/);
 
-  assert.match(lockfile, /terraform init/);
-  assert.match(lockfile, /provider locks/);
+  assert.ok(lockfile.trim().length > 0);
+  assert.ok(
+    /terraform init|provider\s+"registry\.terraform\.io\/linode\/linode"/.test(
+      lockfile,
+    ),
+  );
 });
 
 test('gitignore excludes terraform local state and secrets', () => {
@@ -70,4 +78,6 @@ test('infra README documents terraform import and apply workflow', () => {
   assert.match(readme, /terraform import linode_domain\.drdnt_org/);
   assert.match(readme, /terraform plan/);
   assert.match(readme, /terraform apply/);
+  assert.doesNotMatch(readme, /linode_instance_id/);
+  assert.doesNotMatch(readme, /linode_domain_id/);
 });

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -22,6 +22,7 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(mainTf, /source\s*=\s*"linode\/linode"/);
   assert.match(mainTf, /resource "linode_instance" "vps"/);
   assert.match(mainTf, /resource "linode_firewall" "station"/);
+  assert.match(mainTf, /prevent_destroy = true/);
   assert.match(mainTf, /ports\s*=\s*"22"/);
   assert.match(mainTf, /ports\s*=\s*"80"/);
   assert.match(mainTf, /ports\s*=\s*"443"/);
@@ -30,6 +31,9 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(dnsTf, /resource "linode_domain_record" "api"/);
   assert.match(dnsTf, /resource "linode_domain_record" "station"/);
   assert.match(dnsTf, /resource "linode_domain_record" "bot"/);
+  assert.match(dnsTf, /locals\s*\{/);
+  assert.match(dnsTf, /linode_instance\.vps\.ip_address/);
+  assert.match(dnsTf, /prevent_destroy = true/);
 
   assert.match(variablesTf, /variable "linode_token"/);
   assert.match(variablesTf, /variable "vps_ip"/);
@@ -38,6 +42,8 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(variablesTf, /variable "vps_type"/);
   assert.match(variablesTf, /variable "vps_image"/);
   assert.match(variablesTf, /variable "ssh_public_key"/);
+  assert.match(variablesTf, /nullable\s*=\s*true/);
+  assert.match(variablesTf, /default\s*=\s*null/);
 
   assert.match(outputsTf, /output "vps_ip"/);
   assert.match(outputsTf, /output "api_fqdn"/);

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -34,6 +34,7 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(dnsTf, /locals\s*\{/);
   assert.match(dnsTf, /linode_instance\.vps\.ip_address/);
   assert.match(dnsTf, /prevent_destroy = true/);
+  assert.match(dnsTf, /precondition\s*\{/);
 
   assert.match(variablesTf, /variable "linode_token"/);
   assert.match(variablesTf, /variable "vps_ip"/);
@@ -44,6 +45,7 @@ test('terraform configuration files exist and define the Linode foundation', () 
   assert.match(variablesTf, /variable "ssh_public_key"/);
   assert.match(variablesTf, /nullable\s*=\s*true/);
   assert.match(variablesTf, /default\s*=\s*null/);
+  assert.match(variablesTf, /validation\s*\{/);
 
   assert.match(outputsTf, /output "vps_ip"/);
   assert.match(outputsTf, /output "api_fqdn"/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,8 @@ importers:
         specifier: ^2.3.0
         version: 2.6.1
 
+  infra: {}
+
   backend:
     dependencies:
       '@nestjs/axios':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'backend'
   - 'frontend'
+  - 'infra'


### PR DESCRIPTION
## Summary
- add Terraform scaffolding for the Linode instance, firewall, DNS, and outputs
- document the Terraform import and apply workflow under infra
- add repeatable infra tests for Terraform files and gitignore coverage

## Testing
- pnpm --filter infra test

## Notes
- Terraform was not installed in this environment, so `.terraform.lock.hcl` is committed as a bootstrap placeholder and should be populated by running `terraform init` on a machine with Terraform available.

Closes #106