### PR TITLE
fix: align main deploy workflow test env with validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
           DATABASE_USER: test
           DATABASE_PASSWORD: test
           DATABASE_NAME: station_test
-          JWT_SECRET: test-secret-key
+          JWT_SECRET: test-secret-key-for-ci-minimum-32-chars
         run: pnpm run test:e2e
 
   build:

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('AppController (e2e)', () => {
   });
 
   afterEach(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('/ (GET)', () => {

--- a/backend/test/auth-password-reset.e2e-spec.ts
+++ b/backend/test/auth-password-reset.e2e-spec.ts
@@ -74,7 +74,7 @@ describe('Auth - Password Reset (e2e)', () => {
     await passwordResetRepository.delete({ userId: testUser.id });
     await userRepository.delete({ id: testUser.id });
 
-    await app.close();
+    await app?.close();
   });
 
   describe('POST /auth/forgot-password', () => {

--- a/backend/test/auth-rate-limit.e2e-spec.ts
+++ b/backend/test/auth-rate-limit.e2e-spec.ts
@@ -62,7 +62,7 @@ describe('Auth - Rate Limiting (e2e)', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   it('should return 429 after exceeding the login rate limit', async () => {

--- a/backend/test/games.e2e-spec.ts
+++ b/backend/test/games.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('Games (e2e)', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('GamesService', () => {

--- a/backend/test/organizations.e2e-spec.ts
+++ b/backend/test/organizations.e2e-spec.ts
@@ -59,7 +59,7 @@ describe('Organizations (e2e)', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('/organizations (POST)', () => {

--- a/backend/test/roles.e2e-spec.ts
+++ b/backend/test/roles.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('Roles (e2e)', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('/roles (POST)', () => {

--- a/backend/test/test-config.ts
+++ b/backend/test/test-config.ts
@@ -14,5 +14,5 @@ export const getTestDatabaseConfig = (): TypeOrmModuleOptions => ({
 });
 
 export const getTestJwtSecret = (): string => {
-  return process.env.JWT_SECRET || 'test-jwt-secret-key-for-local-e2e-tests';
+  return process.env.JWT_SECRET || 'test-jwt-secret-key';
 };

--- a/backend/test/test-config.ts
+++ b/backend/test/test-config.ts
@@ -14,5 +14,5 @@ export const getTestDatabaseConfig = (): TypeOrmModuleOptions => ({
 });
 
 export const getTestJwtSecret = (): string => {
-  return process.env.JWT_SECRET || 'test-jwt-secret-key';
+  return process.env.JWT_SECRET || 'test-jwt-secret-key-for-local-e2e-tests';
 };

--- a/backend/test/user-organization-roles.e2e-spec.ts
+++ b/backend/test/user-organization-roles.e2e-spec.ts
@@ -94,7 +94,7 @@ describe('UserOrganizationRoles (e2e)', () => {
   });
 
   afterAll(async () => {
-    await app.close();
+    await app?.close();
   });
 
   describe('/user-organization-roles/assign (POST)', () => {


### PR DESCRIPTION
## Summary
- update the legacy `main` deploy workflow E2E environment to use a 32+ character `JWT_SECRET`
- make E2E teardowns use optional close calls so failed bootstrap does not add noisy `app.close()` follow-on errors

## Testing
- `git diff --check`
- `pnpm --dir backend run test:e2e -- test/app.e2e-spec.ts test/auth-rate-limit.e2e-spec.ts test/roles.e2e-spec.ts`

Closes #142