### PR TITLE
feat: enable redis aof persistence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,6 +432,16 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${VPS_USER}@${VPS_HOST}" \
             "cd /opt/station && BACKUP_LABEL=pre-deploy-${GITHUB_SHA::7} bash infra/scripts/backup-db.sh"
 
+      - name: Verify pre-deploy backup uploaded
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          ssh -o StrictHostKeyChecking=yes "${VPS_USER}@${VPS_HOST}" \
+            "cd /opt/station && export RCLONE_CONFIG=/opt/station/rclone.conf && \
+             source /opt/station/.env.production && \
+             rclone ls \"b2:${B2_BUCKET}/postgres/\" | grep \"pre-deploy-${GITHUB_SHA::7}\\.sql.gz\""
+
       - name: Deploy production
         env:
           STATION_VERSION: ${{ needs.build-and-push.outputs.version }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,9 +56,14 @@ services:
     restart: unless-stopped
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set in .env.production}
-    command: sh -c 'redis-server --requirepass "$$REDIS_PASSWORD" --appendonly yes'
+    command:
+      [
+        "sh",
+        "-c",
+        "redis-server --requirepass \"$$REDIS_PASSWORD\" --appendonly yes --appendfsync everysec",
+      ]
     volumes:
-      - redis_data:/data
+      - redis_aof:/data
     healthcheck:
       test: ['CMD-SHELL', 'redis-cli -a "$$REDIS_PASSWORD" ping']
       interval: 10s
@@ -68,4 +73,4 @@ services:
 
 volumes:
   postgres_data:
-  redis_data:
+  redis_aof:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -56,9 +56,14 @@ services:
     restart: unless-stopped
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set in .env.staging}
-    command: sh -c 'redis-server --requirepass "$$REDIS_PASSWORD" --appendonly yes'
+    command:
+      [
+        "sh",
+        "-c",
+        "redis-server --requirepass \"$$REDIS_PASSWORD\" --appendonly yes --appendfsync everysec",
+      ]
     volumes:
-      - redis_staging_data:/data
+      - redis_staging_aof:/data
     healthcheck:
       test: ['CMD-SHELL', 'redis-cli -a "$$REDIS_PASSWORD" ping']
       interval: 10s
@@ -68,4 +73,4 @@ services:
 
 volumes:
   postgres_staging_data:
-  redis_staging_data:
+  redis_staging_aof:

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -84,6 +84,7 @@ bash infra/scripts/deploy.sh
 
 The release workflow rewrites `/opt/station/.env.production` before every production deploy and locks it down with `chmod 600`.
 It also writes `/opt/station/rclone.conf` from the production B2 secrets and runs a pre-deploy PostgreSQL backup before the backend rollout begins.
+The production job then verifies that the labeled pre-deploy backup exists in Backblaze B2 before continuing.
 
 ## Rollback
 
@@ -98,6 +99,7 @@ It also writes `/opt/station/rclone.conf` from the production B2 secrets and run
 - The shared staging and production deploy jobs also use a global `station-deploy` concurrency group so different release branches cannot race each other on the same VPS or image promotion path.
 - Release deployments pin the target host through `VPS_KNOWN_HOSTS` and use `StrictHostKeyChecking=yes` instead of trusting first use.
 - Production deploys fail closed if the pre-deploy backup cannot be created and uploaded to Backblaze B2.
+- Redis now uses AOF persistence with `appendfsync everysec` in both staging and production; see `infra/docs/redis.md` for verification and recovery notes.
 - Backend and frontend CI still run on `release/**` pushes, but the release workflow no longer depends on those separate runs to gate deploys because it executes the same validation steps itself.
 - The release workflow shell-quotes `STATION_VERSION` before sending it over SSH so the remote deploy treats the version as data rather than shell syntax.
 - Health-check polling bounds each `curl` attempt with explicit connect and total timeouts so a single hung request cannot stall the full deploy window.

--- a/infra/README.md
+++ b/infra/README.md
@@ -88,3 +88,11 @@ Issue `#125` adds the production backup contract:
 - `infra/logrotate/station-backup`: rotates `/opt/station/logs/backup.log`
 
 The production release workflow writes `/opt/station/rclone.conf` from GitHub environment secrets and runs a pre-deploy backup before rolling the backend forward.
+
+## Redis Persistence
+
+Issue `#126` enables Redis AOF persistence in both compose stacks and documents verification/recovery in `infra/docs/redis.md`.
+
+- production uses the `redis_aof` volume
+- staging uses the `redis_staging_aof` volume
+- both Redis services run with `--appendonly yes --appendfsync everysec`

--- a/infra/docs/redis.md
+++ b/infra/docs/redis.md
@@ -1,0 +1,56 @@
+# Redis Persistence
+
+Station runs Redis with Append-Only File (AOF) persistence enabled in both staging and production.
+
+## Why AOF
+
+Redis is used for token/session-adjacent state and cached permission data. With AOF enabled and `appendfsync everysec`, Redis flushes writes to disk every second. That reduces worst-case data loss on a crash from minutes to roughly one second.
+
+## Compose Configuration
+
+The Redis services use:
+
+- `--appendonly yes`
+- `--appendfsync everysec`
+- dedicated AOF-backed named volumes:
+  - `redis_aof` in production
+  - `redis_staging_aof` in staging
+
+## Verify AOF Is Active
+
+Production:
+
+```bash
+docker compose --env-file .env.production -f docker-compose.prod.yml exec redis \
+  redis-cli -a "${REDIS_PASSWORD}" INFO persistence | grep aof_enabled
+```
+
+Staging:
+
+```bash
+docker compose --project-name station-staging --env-file .env.staging -f docker-compose.staging.yml exec redis \
+  redis-cli -a "${REDIS_PASSWORD}" INFO persistence | grep aof_enabled
+```
+
+Expected output:
+
+```text
+aof_enabled:1
+```
+
+## Inspect AOF File Size
+
+```bash
+docker compose --env-file .env.production -f docker-compose.prod.yml exec redis \
+  redis-cli -a "${REDIS_PASSWORD}" INFO persistence | grep aof_current_size
+```
+
+## If Redis Data Is Lost
+
+Redis is not the system of record. If the Redis AOF volume is lost:
+
+1. the application should still boot
+2. cached permission and organization-member lookups rebuild on demand
+3. users may need to sign in again if session-related entries were lost
+
+This is degraded behavior, not a database disaster. No B2 restore flow is required for Redis in the current architecture.

--- a/infra/scripts/backup-db.sh
+++ b/infra/scripts/backup-db.sh
@@ -26,7 +26,7 @@ set +a
 : "${DATABASE_NAME:?DATABASE_NAME is required}"
 : "${B2_BUCKET:?B2_BUCKET is required}"
 
-LABEL="${1:-${BACKUP_LABEL:-nightly}}"
+LABEL="${BACKUP_LABEL:-${1:-nightly}}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 BACKUP_FILE="/tmp/station_backup_${TIMESTAMP}_${LABEL}.sql.gz"
 REMOTE_PATH="postgres/${TIMESTAMP:0:6}/${TIMESTAMP}_${LABEL}.sql.gz"

--- a/infra/tests/infrastructure.test.mjs
+++ b/infra/tests/infrastructure.test.mjs
@@ -167,7 +167,7 @@ test('backup and restore scripts use docker compose and rclone with production e
   assert.match(backupScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T postgres/);
   assert.match(backupScript, /pg_dump -U "\$\{DATABASE_USER\}" -d "\$\{DATABASE_NAME\}"/);
   assert.match(backupScript, /rclone copyto "\$\{BACKUP_FILE\}" "b2:\$\{B2_BUCKET\}\/\$\{REMOTE_PATH\}"/);
-  assert.match(backupScript, /LABEL="\$\{1:-\$\{BACKUP_LABEL:-nightly\}\}"/);
+  assert.match(backupScript, /LABEL="\$\{BACKUP_LABEL:-\$\{1:-nightly\}\}"/);
   assert.match(backupScript, /BACKUP_HEALTHCHECK_URL/);
   assert.match(backupScript, /curl -fsS --retry 3 "\$\{BACKUP_HEALTHCHECK_URL\}"/);
 
@@ -182,6 +182,26 @@ test('backup and restore scripts use docker compose and rclone with production e
   assert.match(logrotateConfig, /weekly/);
   assert.match(logrotateConfig, /rotate 12/);
   assert.match(logrotateConfig, /compress/);
+});
+
+test('redis compose services use AOF persistence in staging and production', () => {
+  const prodCompose = readInfraFile('../docker-compose.prod.yml');
+  const stagingCompose = readInfraFile('../docker-compose.staging.yml');
+  const redisDoc = readInfraFile('docs/redis.md');
+
+  assert.match(prodCompose, /appendonly yes --appendfsync everysec/);
+  assert.match(prodCompose, /redis_aof:\/data/);
+  assert.match(prodCompose, /redis_aof:/);
+
+  assert.match(stagingCompose, /appendonly yes --appendfsync everysec/);
+  assert.match(stagingCompose, /redis_staging_aof:\/data/);
+  assert.match(stagingCompose, /redis_staging_aof:/);
+
+  assert.match(redisDoc, /^# Redis Persistence$/m);
+  assert.match(redisDoc, /appendfsync everysec/);
+  assert.match(redisDoc, /aof_enabled:1/);
+  assert.match(redisDoc, /aof_current_size/);
+  assert.match(redisDoc, /users may need to sign in again/);
 });
 
 test('swap script creates and persists a 2 GB swap file', () => {
@@ -308,6 +328,9 @@ test('release workflow safely quotes station version for remote deploys', () => 
   assert.match(workflow, /chmod 600 \/opt\/station\/rclone\.conf/);
   assert.match(workflow, /Pre-deploy database backup/);
   assert.match(workflow, /BACKUP_LABEL=pre-deploy-\$\{GITHUB_SHA::7\} bash infra\/scripts\/backup-db\.sh/);
+  assert.match(workflow, /Verify pre-deploy backup uploaded/);
+  assert.match(workflow, /rclone ls \\"b2:\$\{B2_BUCKET\}\/postgres\/\\"/);
+  assert.match(workflow, /grep \\"pre-deploy-\$\{GITHUB_SHA::7\}/);
   assert.match(workflow, /curl --fail --silent --show-error --connect-timeout 5 --max-time "\$max_time"/);
   assert.match(workflow, /deadline=\$\(\(SECONDS \+ 120\)\)/);
 });
@@ -450,6 +473,7 @@ test('release workflow and CI branch rules are configured', () => {
   assert.match(cicdDoc, /B2_APPLICATION_KEY/);
   assert.match(cicdDoc, /rclone\.conf/);
   assert.match(cicdDoc, /pre-deploy PostgreSQL backup/);
+  assert.match(cicdDoc, /verifies that the labeled pre-deploy backup exists in Backblaze B2/);
   assert.match(cicdDoc, /BACKUP_HEALTHCHECK_URL/);
   assert.match(cicdDoc, /staging-up\.sh/);
   assert.match(cicdDoc, /station-staging/);
@@ -465,6 +489,7 @@ test('release workflow and CI branch rules are configured', () => {
   assert.match(cicdDoc, /global `station-deploy` concurrency group/);
   assert.match(cicdDoc, /postgres:16-alpine/);
   assert.match(cicdDoc, /Backend and frontend CI still run on `release\/\*\*` pushes, but the release workflow no longer depends on those separate runs to gate deploys/);
+  assert.match(cicdDoc, /Redis now uses AOF persistence/);
   assert.match(cicdDoc, /Rollback/);
 
   assert.match(secretsDoc, /^# Secrets Management$/m);


### PR DESCRIPTION
Closes #126

## Summary
- enable Redis AOF persistence with `appendfsync everysec` in both production and staging compose stacks and rename the Redis volumes accordingly
- verify the labeled pre-deploy PostgreSQL backup exists in B2 before production deploy continues
- document Redis persistence and recovery in `infra/docs/redis.md`, plus update CI/CD and infra tests to match the new deploy contract

## Testing
- `git -C /tmp/station-issue-126 diff --check`
- `node /tmp/station-issue-126/infra/tests/infrastructure.test.mjs`

## Notes
- `#126` is now `In Progress` on the Station Kanban Board
- `backup-db.sh` now prefers `BACKUP_LABEL` over the positional label argument so the release workflow can stamp pre-deploy snapshots consistently
- no new GitHub environment secrets are required for this ticket beyond the B2 secrets already introduced in `#125`